### PR TITLE
Add initial RTL

### DIFF
--- a/.github/verible-lint-matcher.json
+++ b/.github/verible-lint-matcher.json
@@ -1,0 +1,16 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "verible-lint-matcher",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):(\\d+):\\s(.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: ci
+on: [push]
+
+jobs:
+  ################
+  # Verible Lint #
+  ################
+  verilog:
+    name: Verilog Sources
+    # This job runs on Linux (fixed ubuntu version)
+    runs-on: ubuntu-18.04
+    env:
+      VERIBLE_VERSION: 0.0-807-g10e7c71
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Verible
+      run: |
+        set -e
+        mkdir -p build/verible
+        cd build/verible
+        curl -Ls -o verible.tar.gz https://github.com/google/verible/releases/download/v$VERIBLE_VERSION/verible-v$VERIBLE_VERSION-Ubuntu-18.04-bionic-x86_64.tar.gz
+        sudo mkdir -p /tools/verible && sudo chmod 777 /tools/verible
+        tar -C /tools/verible -xf verible.tar.gz --strip-components=1
+        echo "PATH=$PATH:/tools/verible/bin" >> $GITHUB_ENV
+    # Run linter in hw/ip subdir
+    - name: Run Lint
+      run: |
+        echo "::add-matcher::.github/verible-lint-matcher.json"
+        find src \
+            -name "*.sv" | \
+            xargs verible-verilog-lint --waiver_files lint/common_cells.style.waiver --rules=-interface-name-style --lint_fatal
+        echo "::remove-matcher owner=verible-lint-matcher::"

--- a/Bender.yml
+++ b/Bender.yml
@@ -1,0 +1,28 @@
+# Copyright 2020 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+package:
+  name: acc_interface
+  authors:
+  - Noam Gallmann <gnoam@live.com>
+
+dependencies:
+  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.21.0 }
+
+export_include_dirs:
+  - include
+
+sources:
+  # TODO: Level dependencies
+  - src/acc_pkg.sv
+  - src/acc_intf.sv
+  - src/acc_interconnect.sv
+  - src/acc_adapter.sv
+  - src/acc_predecoder.sv
+  - target: simulation
+    files:
+      - src/acc_test.sv
+  - target: test
+    files:
+      - test/acc_interconnect_tb.sv
+      - test/acc_adapter_tb.sv

--- a/include/acc_interface/assign.svh
+++ b/include/acc_interface/assign.svh
@@ -36,21 +36,18 @@
 //
 // Usage Example: `ACC_C_C_ASSIGN(slv, mst) `ACC_C_C_ASSIGN_Q(dst, src, aw)
 // `ACC_C_ASSIGN_P(dst, src)
-`define ACC_C_ASSIGN_Q_CHAN(__opt_as, dst, src, __sep_dst, __sep_src) \
-  __opt_as dst.q``__sep_dst``addr      = src.q``__sep_src``addr;      \
-  __opt_as dst.q``__sep_dst``data_op   = src.q``__sep_src``data_op;   \
-  __opt_as dst.q``__sep_dst``data_arga = src.q``__sep_src``data_arga; \
-  __opt_as dst.q``__sep_dst``data_argb = src.q``__sep_src``data_argb; \
-  __opt_as dst.q``__sep_dst``data_argc = src.q``__sep_src``data_argc; \
-  __opt_as dst.q``__sep_dst``hart_id   = src.q``__sep_src``hart_id;
+`define ACC_C_ASSIGN_Q_CHAN(__opt_as, dst, src, __sep_dst, __sep_src)   \
+  __opt_as dst.q``__sep_dst``addr       = src.q``__sep_src``addr;       \
+  __opt_as dst.q``__sep_dst``instr_data = src.q``__sep_src``instr_data; \
+  __opt_as dst.q``__sep_dst``rs         = src.q``__sep_src``rs;         \
+  __opt_as dst.q``__sep_dst``hart_id    = src.q``__sep_src``hart_id;
 
-`define ACC_C_ASSIGN_P_CHAN(__opt_as, dst, src, __sep_dst, __sep_src)           \
-  __opt_as dst.p``__sep_dst``data0          = src.p``__sep_src``data0;          \
-  __opt_as dst.p``__sep_dst``data1          = src.p``__sep_src``data1;          \
-  __opt_as dst.p``__sep_dst``error          = src.p``__sep_src``error;          \
-  __opt_as dst.p``__sep_dst``dual_writeback = src.p``__sep_src``dual_writeback; \
-  __opt_as dst.p``__sep_dst``hart_id        = src.p``__sep_src``hart_id;        \
-  __opt_as dst.p``__sep_dst``rd             = src.p``__sep_src``rd;
+`define ACC_C_ASSIGN_P_CHAN(__opt_as, dst, src, __sep_dst, __sep_src) \
+  __opt_as dst.p``__sep_dst``data    = src.p``__sep_src``data;        \
+  __opt_as dst.p``__sep_dst``error   = src.p``__sep_src``error;       \
+  __opt_as dst.p``__sep_dst``dualwb  = src.p``__sep_src``dualwb;      \
+  __opt_as dst.p``__sep_dst``hart_id = src.p``__sep_src``hart_id;     \
+  __opt_as dst.p``__sep_dst``rd      = src.p``__sep_src``rd;
 
 `define ACC_C_ASSIGN(slv, mst)                 \
   `ACC_C_ASSIGN_Q_CHAN(assign, slv, mst, _, _) \
@@ -64,21 +61,18 @@
 //
 // Usage example: `ACC_C_ASSIGN_Q_SIGNALS(assign, slv_req_o.q, slv_req_q_chan, "id", sender_id);
 `define ACC_C_ASSIGN_Q_SIGNALS(__opt_as, dst, src,  ovr_name = "none", ovr_sig = '0) \
-  __opt_as dst.addr      = ``ovr_name`` == "addr" ? ovr_sig : src.addr;              \
-  __opt_as dst.data_op   = ``ovr_name`` == "data_op" ? ovr_sig : src.data_op;        \
-  __opt_as dst.data_arga = ``ovr_name`` == "data_arga" ? ovr_sig : src.data_arga;    \
-  __opt_as dst.data_argb = ``ovr_name`` == "data_argb" ? ovr_sig : src.data_argb;    \
-  __opt_as dst.data_argc = ``ovr_name`` == "data_argc" ? ovr_sig : src.data_argc;    \
-  __opt_as dst.hart_id   = ``ovr_name`` == "hart_id" ? ovr_sig : src.hart_id;
+  __opt_as dst.addr       = ``ovr_name`` == "addr"       ? ovr_sig : src.addr;       \
+  __opt_as dst.instr_data = ``ovr_name`` == "instr_data" ? ovr_sig : src.instr_data; \
+  __opt_as dst.rs         = ``ovr_name`` == "rs"         ? ovr_sig : src.rs;         \
+  __opt_as dst.hart_id    = ``ovr_name`` == "hart_id"    ? ovr_sig : src.hart_id;
 
   // Assign P_channel signals with override.
-`define ACC_C_ASSIGN_P_SIGNALS(__opt_as, dst, src,  ovr_name="none", ovr_sig='0)                 \
-  __opt_as dst.data0          = ``ovr_name`` == "data0" ? ovr_sig : src.data0;                   \
-  __opt_as dst.data1          = ``ovr_name`` == "data1" ? ovr_sig : src.data1;                   \
-  __opt_as dst.dual_writeback = ``ovr_name`` == "dual_writeback" ? ovr_sig : src.dual_writeback; \
-  __opt_as dst.error          = ``ovr_name`` == "error" ? ovr_sig : src.error;                   \
-  __opt_as dst.hart_id        = ``ovr_name`` == "hart_id" ? ovr_sig : src.hart_id;               \
-  __opt_as dst.rd             = ``ovr_name`` == "rd" ? ovr_sig : src.rd;
+`define ACC_C_ASSIGN_P_SIGNALS(__opt_as, dst, src,  ovr_name="none", ovr_sig='0) \
+  __opt_as dst.data    = ``ovr_name`` == "data"    ? ovr_sig : src.data;         \
+  __opt_as dst.dualwb  = ``ovr_name`` == "dualwb"  ? ovr_sig : src.dualwb;       \
+  __opt_as dst.error   = ``ovr_name`` == "error"   ? ovr_sig : src.error;        \
+  __opt_as dst.hart_id = ``ovr_name`` == "hart_id" ? ovr_sig : src.hart_id;      \
+  __opt_as dst.rd      = ``ovr_name`` == "rd"      ? ovr_sig : src.rd;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -142,9 +136,7 @@
 
 `define ACC_X_ASSIGN_Q_CHAN(__opt_as, dst, src, __sep_dst, __sep_src)   \
   __opt_as dst.q``__sep_dst``instr_data = src.q``__sep_src``instr_data; \
-  __opt_as dst.q``__sep_dst``rs1        = src.q``__sep_src``rs1;        \
-  __opt_as dst.q``__sep_dst``rs2        = src.q``__sep_src``rs2;        \
-  __opt_as dst.q``__sep_dst``rs3        = src.q``__sep_src``rs3;        \
+  __opt_as dst.q``__sep_dst``rs         = src.q``__sep_src``rs;         \
   __opt_as dst.q``__sep_dst``rs_valid   = src.q``__sep_src``rs_valid;   \
   __opt_as dst.q``__sep_dst``rd_clean   = src.q``__sep_src``rd_clean;
 
@@ -152,20 +144,18 @@
   __opt_as dst.k``__sep_dst``accept    = src.k``__sep_src``accept;    \
   __opt_as dst.k``__sep_dst``writeback = src.k``__sep_src``writeback;
 
-`define ACC_X_ASSIGN_P_CHAN(__opt_as, dst, src, __sep_dst, __sep_src)           \
-  __opt_as dst.p``__sep_dst``data0          = src.p``__sep_src``data0;          \
-  __opt_as dst.p``__sep_dst``data1          = src.p``__sep_src``data1;          \
-  __opt_as dst.p``__sep_dst``error          = src.p``__sep_src``error;          \
-  __opt_as dst.p``__sep_dst``dual_writeback = src.p``__sep_src``dual_writeback; \
-  __opt_as dst.p``__sep_dst``rd             = src.p``__sep_src``rd;
+`define ACC_X_ASSIGN_P_CHAN(__opt_as, dst, src, __sep_dst, __sep_src) \
+  __opt_as dst.p``__sep_dst``data   = src.p``__sep_src``data;         \
+  __opt_as dst.p``__sep_dst``error  = src.p``__sep_src``error;        \
+  __opt_as dst.p``__sep_dst``dualwb = src.p``__sep_src``dualwb;       \
+  __opt_as dst.p``__sep_dst``rd     = src.p``__sep_src``rd;
 
   // Assign P_channel signals with override.
-`define ACC_X_ASSIGN_P_SIGNALS(__opt_as, dst, src,  ovr_name="none", ovr_sig='0)                 \
-  __opt_as dst.data0          = ``ovr_name`` == "data0" ? ovr_sig : src.data0;                   \
-  __opt_as dst.data1          = ``ovr_name`` == "data1" ? ovr_sig : src.data1;                   \
-  __opt_as dst.dual_writeback = ``ovr_name`` == "dual_writeback" ? ovr_sig : src.dual_writeback; \
-  __opt_as dst.error          = ``ovr_name`` == "error" ? ovr_sig : src.error;                   \
-  __opt_as dst.rd             = ``ovr_name`` == "rd" ? ovr_sig : src.rd;
+`define ACC_X_ASSIGN_P_SIGNALS(__opt_as, dst, src,  ovr_name="none", ovr_sig='0) \
+  __opt_as dst.data   = ``ovr_name`` == "data"   ? ovr_sig : src.data;           \
+  __opt_as dst.dualwb = ``ovr_name`` == "dualwb" ? ovr_sig : src.dualwb;         \
+  __opt_as dst.error  = ``ovr_name`` == "error"  ? ovr_sig : src.error;          \
+  __opt_as dst.rd     = ``ovr_name`` == "rd"     ? ovr_sig : src.rd;
 
 `define ACC_X_ASSIGN(slv, mst)                 \
   `ACC_X_ASSIGN_Q_CHAN(assign, slv, mst, _, _) \

--- a/include/acc_interface/assign.svh
+++ b/include/acc_interface/assign.svh
@@ -1,0 +1,240 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Noam Gallmann <gnoam@live.com>
+
+// Macros to assign accelerator interfaces and structs
+
+/////////////////////
+// ACC_C Interface //
+/////////////////////
+
+`ifndef ACC_C_ASSIGN_SVH_
+`define ACC_C_ASSIGN_SVH_
+
+// Assign handshake.
+`define ACC_ASSIGN_VALID(__opt_as, __dst, __src, __chan) \
+  __opt_as ``__dst``.``__chan``_valid   = ``__src``.``__chan``_valid;
+
+`define ACC_ASSIGN_READY(__opt_as, __dst, __src, __chan) \
+  __opt_as ``__dst``.``__chan``_ready   = ``__src``.``__chan``_ready;
+
+`define ACC_ASSIGN_HANDSHAKE(__opt_as, __dst, __src, __chan) \
+  `ACC_ASSIGN_VALID(__opt_as, __dst, __src, __chan)          \
+  `ACC_ASSIGN_READY(__opt_as, __src, __dst, __chan)
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Assigning one C interface to another, as if you would do `assign slv =
+// mst;`
+//
+// The channel assignments `ACC_C_ASSIGN_XX(dst, src)` assign all payload and
+// the valid signal of the `XX` channel from the `src` to the `dst` interface
+// and they assign the ready signal from the `src` to the `dst` interface. The
+// interface assignment `ACC_C_ASSIGN(dst, src)` assigns all channels including
+// handshakes as if `src` was the master of `dst`.
+//
+// Usage Example: `ACC_C_C_ASSIGN(slv, mst) `ACC_C_C_ASSIGN_Q(dst, src, aw)
+// `ACC_C_ASSIGN_P(dst, src)
+`define ACC_C_ASSIGN_Q_CHAN(__opt_as, dst, src, __sep_dst, __sep_src) \
+  __opt_as dst.q``__sep_dst``addr      = src.q``__sep_src``addr;      \
+  __opt_as dst.q``__sep_dst``data_op   = src.q``__sep_src``data_op;   \
+  __opt_as dst.q``__sep_dst``data_arga = src.q``__sep_src``data_arga; \
+  __opt_as dst.q``__sep_dst``data_argb = src.q``__sep_src``data_argb; \
+  __opt_as dst.q``__sep_dst``data_argc = src.q``__sep_src``data_argc; \
+  __opt_as dst.q``__sep_dst``id        = src.q``__sep_src``id;
+
+`define ACC_C_ASSIGN_P_CHAN(__opt_as, dst, src, __sep_dst, __sep_src)           \
+  __opt_as dst.p``__sep_dst``data0          = src.p``__sep_src``data0;          \
+  __opt_as dst.p``__sep_dst``data1          = src.p``__sep_src``data1;          \
+  __opt_as dst.p``__sep_dst``error          = src.p``__sep_src``error;          \
+  __opt_as dst.p``__sep_dst``dual_writeback = src.p``__sep_src``dual_writeback; \
+  __opt_as dst.p``__sep_dst``id             = src.p``__sep_src``id;             \
+  __opt_as dst.p``__sep_dst``rd             = src.p``__sep_src``rd;
+
+`define ACC_C_ASSIGN(slv, mst)                 \
+  `ACC_C_ASSIGN_Q_CHAN(assign, slv, mst, _, _) \
+  `ACC_ASSIGN_HANDSHAKE(assign, slv, mst, q)   \
+  `ACC_C_ASSIGN_P_CHAN(assign, mst, slv, _, _) \
+  `ACC_ASSIGN_HANDSHAKE(assign, mst, slv, p)
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Assign channel signals from one set of request/response struct to another,
+// substituting one signal with custom defined override signal
+//
+// Usage example: `ACC_C_ASSIGN_Q_SIGNALS(assign, slv_req_o.q, slv_req_q_chan, "id", sender_id);
+`define ACC_C_ASSIGN_Q_SIGNALS(__opt_as, dst, src,  ovr_name="none", ovr_sig='0)  \
+  __opt_as dst.addr      = ``ovr_name`` == "addr" ? ovr_sig : src.addr;           \
+  __opt_as dst.data_op   = ``ovr_name`` == "data_op" ? ovr_sig : src.data_op;     \
+  __opt_as dst.data_arga = ``ovr_name`` == "data_arga" ? ovr_sig : src.data_arga; \
+  __opt_as dst.data_argb = ``ovr_name`` == "data_argb" ? ovr_sig : src.data_argb; \
+  __opt_as dst.data_argc = ``ovr_name`` == "data_argc" ? ovr_sig : src.data_argc; \
+  __opt_as dst.id        = ``ovr_name`` == "id" ? ovr_sig : src.id;
+
+  // Assign P_channel signals with override.
+`define ACC_C_ASSIGN_P_SIGNALS(__opt_as, dst, src,  ovr_name="none", ovr_sig='0)                   \
+  __opt_as dst.data0          = ``ovr_name`` == "data0" ? ovr_sig : src.data0;                   \
+  __opt_as dst.data1          = ``ovr_name`` == "data1" ? ovr_sig : src.data1;                   \
+  __opt_as dst.dual_writeback = ``ovr_name`` == "dual_writeback" ? ovr_sig : src.dual_writeback; \
+  __opt_as dst.error          = ``ovr_name`` == "error" ? ovr_sig : src.error;                   \
+  __opt_as dst.id             = ``ovr_name`` == "id" ? ovr_sig : src.id;                         \
+  __opt_as dst.rd             = ``ovr_name`` == "rd" ? ovr_sig : src.rd;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Assigning an interface from channel or request/response structs outside a
+// process.
+//
+// The request macro `ACC_C_ASSIGN_FROM_REQ(acc_if, req_struct)` assigns the
+// request channel and the request-side handshake signals of the `acc_if`
+// interface from the signals in `req_struct`. The response macro
+// `ACC_C_ASSIGN_FROM_RESP(acc_if, resp_struct)` assigns the response
+// channel and the response-side handshake signals of the `acc_if` interface
+// from the signals in `resp_struct`.
+//
+// Usage Example:
+// `ACC_C_ASSIGN_FROM_REQ(my_if, my_req_struct)
+`define ACC_C_ASSIGN_FROM_REQ(acc_if, req_struct)        \
+  `ACC_ASSIGN_VALID(assign, acc_if, req_struct, q)       \
+  `ACC_C_ASSIGN_Q_CHAN(assign, acc_if, req_struct, _, .) \
+  `ACC_ASSIGN_READY(assign, acc_if, req_struct, p)
+
+`define ACC_C_ASSIGN_FROM_RESP(acc_if, resp_struct)       \
+  `ACC_ASSIGN_READY(assign, acc_if, resp_struct, q)       \
+  `ACC_C_ASSIGN_P_CHAN(assign, acc_if, resp_struct, _, .) \
+  `ACC_ASSIGN_VALID(assign, acc_if, resp_struct, p)
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Assigning channel or request/response structs from an interface outside a
+// process.
+//
+// The request macro `ACC_C_ASSIGN_TO_REQ(acc_if, req_struct)` assigns all
+// signals of `req_struct` payload and request-side handshake signals to the
+// signals in the `acc_if` interface. The response macro
+// `ACC_C_ASSIGN_TO_RESP(acc_if, resp_struct)` assigns all signals of
+// `resp_struct` payload and response-side handshake signals to the signals in
+// the `acc_if` interface.
+//
+// Usage Example:
+// `ACC_C_ASSIGN_TO_REQ(my_req_struct, my_if)
+`define ACC_C_ASSIGN_TO_REQ(req_struct, acc_if)          \
+  `ACC_ASSIGN_VALID(assign, req_struct, acc_if, q)       \
+  `ACC_C_ASSIGN_Q_CHAN(assign, req_struct, acc_if, ., _) \
+  `ACC_ASSIGN_READY(assign, req_struct, acc_if, p)
+
+`define ACC_C_ASSIGN_TO_RESP(resp_struct, acc_if)         \
+  `ACC_ASSIGN_READY(assign, resp_struct, acc_if, q)       \
+  `ACC_C_ASSIGN_P_CHAN(assign, resp_struct, acc_if, ., _) \
+  `ACC_ASSIGN_VALID(assign, resp_struct, acc_if, p)
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////
+// ACC_X Interface //
+/////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Assigning one ACC_Xinterface to another, as if you would do `assign slv =
+// mst;`
+
+`define ACC_X_ASSIGN_Q_CHAN(__opt_as, dst, src, __sep_dst, __sep_src)   \
+  __opt_as dst.q``__sep_dst``instr_data = src.q``__sep_src``instr_data; \
+  __opt_as dst.q``__sep_dst``rs1        = src.q``__sep_src``rs1;        \
+  __opt_as dst.q``__sep_dst``rs2        = src.q``__sep_src``rs2;        \
+  __opt_as dst.q``__sep_dst``rs3        = src.q``__sep_src``rs3;        \
+  __opt_as dst.q``__sep_dst``rs_valid   = src.q``__sep_src``rs_valid;   \
+  __opt_as dst.q``__sep_dst``rd_clean   = src.q``__sep_src``rd_clean;
+
+`define ACC_X_ASSIGN_K_CHAN(__opt_as, dst, src, __sep_dst, __sep_src) \
+  __opt_as dst.k``__sep_dst``accept    = src.k``__sep_src``accept;    \
+  __opt_as dst.k``__sep_dst``writeback = src.k``__sep_src``writeback;
+
+`define ACC_X_ASSIGN_P_CHAN(__opt_as, dst, src, __sep_dst, __sep_src)           \
+  __opt_as dst.p``__sep_dst``data0          = src.p``__sep_src``data0;          \
+  __opt_as dst.p``__sep_dst``data1          = src.p``__sep_src``data1;          \
+  __opt_as dst.p``__sep_dst``error          = src.p``__sep_src``error;          \
+  __opt_as dst.p``__sep_dst``dual_writeback = src.p``__sep_src``dual_writeback; \
+  __opt_as dst.p``__sep_dst``rd             = src.p``__sep_src``rd;
+
+  // Assign P_channel signals with override.
+`define ACC_X_ASSIGN_P_SIGNALS(__opt_as, dst, src,  ovr_name="none", ovr_sig='0)                 \
+  __opt_as dst.data0          = ``ovr_name`` == "data0" ? ovr_sig : src.data0;                   \
+  __opt_as dst.data1          = ``ovr_name`` == "data1" ? ovr_sig : src.data1;                   \
+  __opt_as dst.dual_writeback = ``ovr_name`` == "dual_writeback" ? ovr_sig : src.dual_writeback; \
+  __opt_as dst.error          = ``ovr_name`` == "error" ? ovr_sig : src.error;                   \
+  __opt_as dst.rd             = ``ovr_name`` == "rd" ? ovr_sig : src.rd;
+
+`define ACC_X_ASSIGN(slv, mst)                 \
+  `ACC_X_ASSIGN_Q_CHAN(assign, slv, mst, _, _) \
+  `ACC_ASSIGN_HANDSHAKE(assign, slv, mst, q)   \
+  `ACC_X_ASSIGN_K_CHAN(assign, mst, slv, _, _) \
+  `ACC_X_ASSIGN_P_CHAN(assign, mst, slv, _, _) \
+  `ACC_ASSIGN_HANDSHAKE(assign, mst, slv, p)
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Assigning an interface from channel or request/response structs outside a
+// process.
+
+`define ACC_X_ASSIGN_FROM_REQ(acc_if, req_struct)        \
+  `ACC_ASSIGN_VALID(assign, acc_if, req_struct, q)       \
+  `ACC_X_ASSIGN_Q_CHAN(assign, acc_if, req_struct, _, .) \
+  `ACC_ASSIGN_READY(assign, acc_if, req_struct, p)
+
+`define ACC_X_ASSIGN_FROM_RESP(acc_if, resp_struct)       \
+  `ACC_ASSIGN_READY(assign, acc_if, resp_struct, q)       \
+  `ACC_X_ASSIGN_P_CHAN(assign, acc_if, resp_struct, _, .) \
+  `ACC_X_ASSIGN_K_CHAN(assign, acc_if, resp_struct, _, .) \
+  `ACC_ASSIGN_VALID(assign, acc_if, resp_struct, p)
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Assigning channel or request/response structs from an interface outside a
+// process.
+`define ACC_X_ASSIGN_TO_REQ(req_struct, acc_if)          \
+  `ACC_ASSIGN_VALID(assign, req_struct, acc_if, q)       \
+  `ACC_X_ASSIGN_Q_CHAN(assign, req_struct, acc_if, ., _) \
+  `ACC_ASSIGN_READY(assign, req_struct, acc_if, p)
+
+`define ACC_X_ASSIGN_TO_RESP(resp_struct, acc_if)         \
+  `ACC_ASSIGN_READY(assign, resp_struct, acc_if, q)       \
+  `ACC_X_ASSIGN_P_CHAN(assign, resp_struct, acc_if, ., _) \
+  `ACC_X_ASSIGN_K_CHAN(assign, resp_struct, acc_if, ., _) \
+  `ACC_ASSIGN_VALID(assign, resp_struct, acc_if, p)
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////
+// Predecoder Interface //
+//////////////////////////
+
+`define ACC_PRD_ASSIGN_P_CHAN(__opt_as, dst, src, __sep_dst, __sep_src) \
+  __opt_as dst.p``__sep_dst``writeback = src.p``__sep_src``writeback;   \
+  __opt_as dst.p``__sep_dst``use_rs    = src.p``__sep_src``use_rs;      \
+  __opt_as dst.p``__sep_dst``accept    = src.p``__sep_src``accept;
+
+
+`define ACC_PRD_ASSIGN_Q_CHAN(__opt_as, dst, src, __sep_dst, __sep_src) \
+  __opt_as dst.q``__sep_dst``instr_data    = src.q``__sep_src``instr_data;
+
+`define ACC_PRD_ASSIGN(slv, mst)                 \
+  `ACC_PRD_ASSIGN_Q_CHAN(assign, slv, mst, _, _) \
+  `ACC_PRD_ASSIGN_P_CHAN(assign, mst, slv, _, _)
+
+`define ACC_PRD_ASSIGN_FROM_REQ(acc_if, req_struct) \
+  `ACC_PRD_ASSIGN_Q_CHAN(assign, acc_if, req_struct, _, _)
+
+`define ACC_PRD_ASSIGN_FROM_RESP(acc_if, resp_struct) \
+  `ACC_PRD_ASSIGN_P_CHAN(assign, acc_if, resp_struct, _, _)
+
+`define ACC_PRD_ASSIGN_TO_REQ(req_struct, acc_if) \
+  `ACC_PRD_ASSIGN_Q_CHAN(assign, req_struct, acc_if, _, _)
+
+`define ACC_PRD_ASSIGN_TO_RESP(resp_struct, acc_if) \
+  `ACC_PRD_ASSIGN_P_CHAN(assign, resp_struct, acc_if, _, _)
+
+`endif

--- a/include/acc_interface/assign.svh
+++ b/include/acc_interface/assign.svh
@@ -42,14 +42,14 @@
   __opt_as dst.q``__sep_dst``data_arga = src.q``__sep_src``data_arga; \
   __opt_as dst.q``__sep_dst``data_argb = src.q``__sep_src``data_argb; \
   __opt_as dst.q``__sep_dst``data_argc = src.q``__sep_src``data_argc; \
-  __opt_as dst.q``__sep_dst``id        = src.q``__sep_src``id;
+  __opt_as dst.q``__sep_dst``hart_id   = src.q``__sep_src``hart_id;
 
 `define ACC_C_ASSIGN_P_CHAN(__opt_as, dst, src, __sep_dst, __sep_src)           \
   __opt_as dst.p``__sep_dst``data0          = src.p``__sep_src``data0;          \
   __opt_as dst.p``__sep_dst``data1          = src.p``__sep_src``data1;          \
   __opt_as dst.p``__sep_dst``error          = src.p``__sep_src``error;          \
   __opt_as dst.p``__sep_dst``dual_writeback = src.p``__sep_src``dual_writeback; \
-  __opt_as dst.p``__sep_dst``id             = src.p``__sep_src``id;             \
+  __opt_as dst.p``__sep_dst``hart_id        = src.p``__sep_src``hart_id;        \
   __opt_as dst.p``__sep_dst``rd             = src.p``__sep_src``rd;
 
 `define ACC_C_ASSIGN(slv, mst)                 \
@@ -63,21 +63,21 @@
 // substituting one signal with custom defined override signal
 //
 // Usage example: `ACC_C_ASSIGN_Q_SIGNALS(assign, slv_req_o.q, slv_req_q_chan, "id", sender_id);
-`define ACC_C_ASSIGN_Q_SIGNALS(__opt_as, dst, src,  ovr_name="none", ovr_sig='0)  \
-  __opt_as dst.addr      = ``ovr_name`` == "addr" ? ovr_sig : src.addr;           \
-  __opt_as dst.data_op   = ``ovr_name`` == "data_op" ? ovr_sig : src.data_op;     \
-  __opt_as dst.data_arga = ``ovr_name`` == "data_arga" ? ovr_sig : src.data_arga; \
-  __opt_as dst.data_argb = ``ovr_name`` == "data_argb" ? ovr_sig : src.data_argb; \
-  __opt_as dst.data_argc = ``ovr_name`` == "data_argc" ? ovr_sig : src.data_argc; \
-  __opt_as dst.id        = ``ovr_name`` == "id" ? ovr_sig : src.id;
+`define ACC_C_ASSIGN_Q_SIGNALS(__opt_as, dst, src,  ovr_name = "none", ovr_sig = '0) \
+  __opt_as dst.addr      = ``ovr_name`` == "addr" ? ovr_sig : src.addr;              \
+  __opt_as dst.data_op   = ``ovr_name`` == "data_op" ? ovr_sig : src.data_op;        \
+  __opt_as dst.data_arga = ``ovr_name`` == "data_arga" ? ovr_sig : src.data_arga;    \
+  __opt_as dst.data_argb = ``ovr_name`` == "data_argb" ? ovr_sig : src.data_argb;    \
+  __opt_as dst.data_argc = ``ovr_name`` == "data_argc" ? ovr_sig : src.data_argc;    \
+  __opt_as dst.hart_id   = ``ovr_name`` == "hart_id" ? ovr_sig : src.hart_id;
 
   // Assign P_channel signals with override.
-`define ACC_C_ASSIGN_P_SIGNALS(__opt_as, dst, src,  ovr_name="none", ovr_sig='0)                   \
+`define ACC_C_ASSIGN_P_SIGNALS(__opt_as, dst, src,  ovr_name="none", ovr_sig='0)                 \
   __opt_as dst.data0          = ``ovr_name`` == "data0" ? ovr_sig : src.data0;                   \
   __opt_as dst.data1          = ``ovr_name`` == "data1" ? ovr_sig : src.data1;                   \
   __opt_as dst.dual_writeback = ``ovr_name`` == "dual_writeback" ? ovr_sig : src.dual_writeback; \
   __opt_as dst.error          = ``ovr_name`` == "error" ? ovr_sig : src.error;                   \
-  __opt_as dst.id             = ``ovr_name`` == "id" ? ovr_sig : src.id;                         \
+  __opt_as dst.hart_id        = ``ovr_name`` == "hart_id" ? ovr_sig : src.hart_id;               \
   __opt_as dst.rd             = ``ovr_name`` == "rd" ? ovr_sig : src.rd;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/acc_interface/typedef.svh
+++ b/include/acc_interface/typedef.svh
@@ -1,0 +1,104 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Noam Gallmann <gnoam@live.com>
+
+// Accelerator Interconnect Typedefs
+`ifndef ACC_C_TYPEDEF_SVH_
+`define ACC_C_TYPEDEF_SVH_
+
+`define ACC_C_TYPEDEF_REQ_CHAN_T(__req_chan_t, __addr_t, __data_t, __id_t) \
+  typedef struct packed {                                                  \
+    __addr_t             addr;                                             \
+    __data_t             data_arga;                                        \
+    __data_t             data_argb;                                        \
+    __data_t             data_argc;                                        \
+    logic [31:0]         data_op;                                          \
+    __id_t               id;                                               \
+  } __req_chan_t;
+
+`define ACC_C_TYPEDEF_REQ_T(__req_t, __req_chan_t) \
+  typedef struct packed {                          \
+    __req_chan_t q;                                \
+    logic        q_valid;                          \
+    logic        p_ready;                          \
+  } __req_t;
+
+`define ACC_C_TYPEDEF_RSP_CHAN_T(__rsp_chan_t, __data_t, __id_t ) \
+  typedef struct packed {                                         \
+    __data_t    data0;                                            \
+    __data_t    data1;                                            \
+    logic       error;                                            \
+    logic       dual_writeback;                                   \
+    __id_t      id;                                               \
+    logic [4:0] rd;                                               \
+  } __rsp_chan_t;
+
+`define ACC_C_TYPEDEF_RSP_T(__rsp_t, __rsp_chan_t) \
+  typedef struct packed {                          \
+    __rsp_chan_t p;                                \
+    logic        p_valid;                          \
+    logic        q_ready;                          \
+  } __rsp_t;
+
+`define ACC_C_TYPEDEF_ALL(__name, __addr_t, __data_t, __id_t )                \
+  `ACC_C_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t, __addr_t, __data_t, __id_t ) \
+  `ACC_C_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __data_t, __id_t )           \
+  `ACC_C_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t )                  \
+  `ACC_C_TYPEDEF_RSP_T(__name``_rsp_t,  __name``_rsp_chan_t )
+
+`endif // ACC_C_TYPEDEF_SVH_
+
+
+`ifndef ACC_X_TYPEDEF_SVH_
+`define ACC_X_TYPEDEF_SVH_
+
+`define ACC_X_TYPEDEF_REQ_T(__req_t, __req_chan_t) \
+  typedef struct packed {                          \
+    __req_chan_t q;                                \
+    logic        q_valid;                          \
+    logic        p_ready;                          \
+  } __req_t;
+
+`define ACC_X_TYPEDEF_REQ_CHAN_T(__req_chan_t, __data_t) \
+  typedef struct packed {                                \
+    logic [31:0] instr_data;                             \
+    __data_t     rs1;                                    \
+    __data_t     rs2;                                    \
+    __data_t     rs3;                                    \
+    logic [2:0]  rs_valid;                               \
+    logic [2:0]  rd_clean;                               \
+  } __req_chan_t;
+
+`define ACC_X_TYPEDEF_RSP_T(__ack_t, __ack_chan_t, __rsp_chan_t) \
+  typedef struct packed {                                        \
+    logic        q_ready;                                        \
+    logic        p_valid;                                        \
+    __ack_chan_t k;                                              \
+    __rsp_chan_t p;                                              \
+  } __ack_t;
+
+`define ACC_X_TYPEDEF_ACK_CHAN_T(__ack_chan_t) \
+  typedef struct packed {                      \
+    logic       accept;                        \
+    logic [1:0] writeback;                     \
+  } __ack_chan_t;
+
+`define ACC_X_TYPEDEF_RSP_CHAN_T(__rsp_chan_t, __data_t, __id_t) \
+  typedef struct packed {                                        \
+    __data_t    data0;                                           \
+    __data_t    data1;                                           \
+    logic       error;                                           \
+    logic       dual_writeback;                                  \
+    logic [4:0] rd;                                              \
+  } __rsp_chan_t;
+
+`define ACC_X_TYPEDEF_ALL(__name, __data_t, __id_t)                \
+  `ACC_X_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t, __data_t)         \
+  `ACC_X_TYPEDEF_ACK_CHAN_T(__name``_ack_chan_t)                   \
+  `ACC_X_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __data_t, __id_t) \
+  `ACC_X_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t)        \
+  `ACC_X_TYPEDEF_RSP_T( __name``_rsp_t, __name``_ack_chan_t, __name``_rsp_chan_t)
+
+`endif // ACC_X_TYPEDEF_SVH_

--- a/include/acc_interface/typedef.svh
+++ b/include/acc_interface/typedef.svh
@@ -8,14 +8,12 @@
 `ifndef ACC_C_TYPEDEF_SVH_
 `define ACC_C_TYPEDEF_SVH_
 
-`define ACC_C_TYPEDEF_REQ_CHAN_T(__req_chan_t, __addr_t, __data_t) \
-  typedef struct packed {                                          \
-    __addr_t     addr;                                             \
-    __data_t     data_arga;                                        \
-    __data_t     data_argb;                                        \
-    __data_t     data_argc;                                        \
-    logic [31:0] data_op;                                          \
-    logic [31:0] hart_id;                                          \
+`define ACC_C_TYPEDEF_REQ_CHAN_T(__req_chan_t, __addr_t, __data_t, __NumRs) \
+  typedef struct packed {                                                   \
+    __addr_t               addr;                                            \
+    __data_t [__NumRs-1:0] rs;                                              \
+    logic    [       31:0] instr_data;                                      \
+    __data_t                hart_id;                                         \
   } __req_chan_t;
 
 `define ACC_C_TYPEDEF_REQ_T(__req_t, __req_chan_t) \
@@ -25,14 +23,13 @@
     logic        p_ready;                          \
   } __req_t;
 
-`define ACC_C_TYPEDEF_RSP_CHAN_T(__rsp_chan_t, __data_t) \
-  typedef struct packed {                                \
-    __data_t     data0;                                  \
-    __data_t     data1;                                  \
-    logic        error;                                  \
-    logic        dual_writeback;                         \
-    logic [31:0] hart_id;                                \
-    logic [4:0]  rd;                                     \
+`define ACC_C_TYPEDEF_RSP_CHAN_T(__rsp_chan_t, __data_t, __NumWb) \
+  typedef struct packed {                                         \
+    __data_t [__NumWb-1:0] data;                                  \
+    logic                  error;                                 \
+    logic                  dualwb;                                \
+    __data_t               hart_id;                               \
+    logic [4:0]            rd;                                    \
   } __rsp_chan_t;
 
 `define ACC_C_TYPEDEF_RSP_T(__rsp_t, __rsp_chan_t) \
@@ -42,10 +39,10 @@
     logic        q_ready;                          \
   } __rsp_t;
 
-`define ACC_C_TYPEDEF_ALL(__name, __addr_t, __data_t)                \
-  `ACC_C_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t, __addr_t, __data_t) \
-  `ACC_C_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __data_t)           \
-  `ACC_C_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t )         \
+`define ACC_C_TYPEDEF_ALL(__name, __addr_t, __data_t, __NumRs, __NumWb)       \
+  `ACC_C_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t, __addr_t, __data_t, __NumRs) \
+  `ACC_C_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __data_t, __NumWb)           \
+  `ACC_C_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t )                  \
   `ACC_C_TYPEDEF_RSP_T(__name``_rsp_t,  __name``_rsp_chan_t )
 
 `endif // ACC_C_TYPEDEF_SVH_
@@ -61,14 +58,12 @@
     logic        p_ready;                          \
   } __req_t;
 
-`define ACC_X_TYPEDEF_REQ_CHAN_T(__req_chan_t, __data_t) \
-  typedef struct packed {                                \
-    logic [31:0] instr_data;                             \
-    __data_t     rs1;                                    \
-    __data_t     rs2;                                    \
-    __data_t     rs3;                                    \
-    logic [2:0]  rs_valid;                               \
-    logic [2:0]  rd_clean;                               \
+`define ACC_X_TYPEDEF_REQ_CHAN_T(__req_chan_t, __data_t, __NumRs, __NumWb) \
+  typedef struct packed {                                                  \
+    logic    [       31:0] instr_data;                                     \
+    __data_t [__NumRs-1:0] rs;                                             \
+    logic    [__NumRs-1:0] rs_valid;                                       \
+    logic    [__NumWb-1:0] rd_clean;                                       \
   } __req_chan_t;
 
 `define ACC_X_TYPEDEF_RSP_T(__ack_t, __ack_chan_t, __rsp_chan_t) \
@@ -79,26 +74,25 @@
     __rsp_chan_t p;                                              \
   } __ack_t;
 
-`define ACC_X_TYPEDEF_ACK_CHAN_T(__ack_chan_t) \
-  typedef struct packed {                      \
-    logic       accept;                        \
-    logic [1:0] writeback;                     \
+`define ACC_X_TYPEDEF_ACK_CHAN_T(__ack_chan_t, __NumWb) \
+  typedef struct packed {                               \
+    logic               accept;                         \
+    logic [__NumWb-1:0] writeback;                      \
   } __ack_chan_t;
 
-`define ACC_X_TYPEDEF_RSP_CHAN_T(__rsp_chan_t, __data_t) \
-  typedef struct packed {                                        \
-    __data_t    data0;                                           \
-    __data_t    data1;                                           \
-    logic       error;                                           \
-    logic       dual_writeback;                                  \
-    logic [4:0] rd;                                              \
+`define ACC_X_TYPEDEF_RSP_CHAN_T(__rsp_chan_t, __data_t, __NumWb) \
+  typedef struct packed {                                         \
+    __data_t [__NumWb-1:0] data;                                  \
+    logic                  error;                                 \
+    logic                  dualwb;                                \
+    logic [4:0]            rd;                                    \
   } __rsp_chan_t;
 
-`define ACC_X_TYPEDEF_ALL(__name, __data_t)                 \
-  `ACC_X_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t, __data_t)  \
-  `ACC_X_TYPEDEF_ACK_CHAN_T(__name``_ack_chan_t)            \
-  `ACC_X_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __data_t)  \
-  `ACC_X_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t) \
+`define ACC_X_TYPEDEF_ALL(__name, __data_t, __NumRs, __NumWb)                \
+  `ACC_X_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t, __data_t, __NumRs, __NumWb) \
+  `ACC_X_TYPEDEF_ACK_CHAN_T(__name``_ack_chan_t, __NumWb)                    \
+  `ACC_X_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __data_t, __NumWb)          \
+  `ACC_X_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t)                  \
   `ACC_X_TYPEDEF_RSP_T( __name``_rsp_t, __name``_ack_chan_t, __name``_rsp_chan_t)
 
 `endif // ACC_X_TYPEDEF_SVH_

--- a/include/acc_interface/typedef.svh
+++ b/include/acc_interface/typedef.svh
@@ -8,14 +8,14 @@
 `ifndef ACC_C_TYPEDEF_SVH_
 `define ACC_C_TYPEDEF_SVH_
 
-`define ACC_C_TYPEDEF_REQ_CHAN_T(__req_chan_t, __addr_t, __data_t, __id_t) \
-  typedef struct packed {                                                  \
-    __addr_t             addr;                                             \
-    __data_t             data_arga;                                        \
-    __data_t             data_argb;                                        \
-    __data_t             data_argc;                                        \
-    logic [31:0]         data_op;                                          \
-    __id_t               id;                                               \
+`define ACC_C_TYPEDEF_REQ_CHAN_T(__req_chan_t, __addr_t, __data_t) \
+  typedef struct packed {                                          \
+    __addr_t     addr;                                             \
+    __data_t     data_arga;                                        \
+    __data_t     data_argb;                                        \
+    __data_t     data_argc;                                        \
+    logic [31:0] data_op;                                          \
+    logic [31:0] hart_id;                                          \
   } __req_chan_t;
 
 `define ACC_C_TYPEDEF_REQ_T(__req_t, __req_chan_t) \
@@ -25,14 +25,14 @@
     logic        p_ready;                          \
   } __req_t;
 
-`define ACC_C_TYPEDEF_RSP_CHAN_T(__rsp_chan_t, __data_t, __id_t ) \
-  typedef struct packed {                                         \
-    __data_t    data0;                                            \
-    __data_t    data1;                                            \
-    logic       error;                                            \
-    logic       dual_writeback;                                   \
-    __id_t      id;                                               \
-    logic [4:0] rd;                                               \
+`define ACC_C_TYPEDEF_RSP_CHAN_T(__rsp_chan_t, __data_t) \
+  typedef struct packed {                                \
+    __data_t     data0;                                  \
+    __data_t     data1;                                  \
+    logic        error;                                  \
+    logic        dual_writeback;                         \
+    logic [31:0] hart_id;                                \
+    logic [4:0]  rd;                                     \
   } __rsp_chan_t;
 
 `define ACC_C_TYPEDEF_RSP_T(__rsp_t, __rsp_chan_t) \
@@ -42,10 +42,10 @@
     logic        q_ready;                          \
   } __rsp_t;
 
-`define ACC_C_TYPEDEF_ALL(__name, __addr_t, __data_t, __id_t )                \
-  `ACC_C_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t, __addr_t, __data_t, __id_t ) \
-  `ACC_C_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __data_t, __id_t )           \
-  `ACC_C_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t )                  \
+`define ACC_C_TYPEDEF_ALL(__name, __addr_t, __data_t)                \
+  `ACC_C_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t, __addr_t, __data_t) \
+  `ACC_C_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __data_t)           \
+  `ACC_C_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t )         \
   `ACC_C_TYPEDEF_RSP_T(__name``_rsp_t,  __name``_rsp_chan_t )
 
 `endif // ACC_C_TYPEDEF_SVH_
@@ -85,7 +85,7 @@
     logic [1:0] writeback;                     \
   } __ack_chan_t;
 
-`define ACC_X_TYPEDEF_RSP_CHAN_T(__rsp_chan_t, __data_t, __id_t) \
+`define ACC_X_TYPEDEF_RSP_CHAN_T(__rsp_chan_t, __data_t) \
   typedef struct packed {                                        \
     __data_t    data0;                                           \
     __data_t    data1;                                           \
@@ -94,11 +94,11 @@
     logic [4:0] rd;                                              \
   } __rsp_chan_t;
 
-`define ACC_X_TYPEDEF_ALL(__name, __data_t, __id_t)                \
-  `ACC_X_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t, __data_t)         \
-  `ACC_X_TYPEDEF_ACK_CHAN_T(__name``_ack_chan_t)                   \
-  `ACC_X_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __data_t, __id_t) \
-  `ACC_X_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t)        \
+`define ACC_X_TYPEDEF_ALL(__name, __data_t)                 \
+  `ACC_X_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t, __data_t)  \
+  `ACC_X_TYPEDEF_ACK_CHAN_T(__name``_ack_chan_t)            \
+  `ACC_X_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __data_t)  \
+  `ACC_X_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t) \
   `ACC_X_TYPEDEF_RSP_T( __name``_rsp_t, __name``_ack_chan_t, __name``_rsp_chan_t)
 
 `endif // ACC_X_TYPEDEF_SVH_

--- a/src/acc_adapter.sv
+++ b/src/acc_adapter.sv
@@ -1,0 +1,319 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Noam Gallmann <gnoam@live.com>
+
+// Adapter between acc-agnostic offloading X-interface and accelerator
+// C-interface
+
+`include "acc_interface/assign.svh"
+`include "acc_interface/typedef.svh"
+
+module acc_adapter #(
+  parameter int unsigned DataWidth        = 32,
+  parameter int          NumHier          = 3,
+  parameter int          NumRsp[NumHier]  = '{4,2,2},
+  parameter type         acc_c_req_t      = logic,
+  parameter type         acc_c_req_chan_t = logic,
+  parameter type         acc_c_rsp_t      = logic,
+  parameter type         acc_x_req_t      = logic,
+  parameter type         acc_x_rsp_t      = logic,
+  // Dependent parameter DO NOT OVERRIDE
+  parameter int NumRspTot                  = acc_pkg::sumn(NumRsp, NumHier)
+) (
+  input clk_i,
+  input rst_ni,
+
+  input  acc_x_req_t acc_x_req_i,
+  output acc_x_rsp_t acc_x_rsp_o,
+
+  output acc_c_req_t acc_c_req_o,
+  input  acc_c_rsp_t acc_c_rsp_i,
+
+  // To predecoders
+  output acc_pkg::acc_prd_req_t [NumRspTot-1:0] acc_prd_req_o,
+  input  acc_pkg::acc_prd_rsp_t [NumRspTot-1:0] acc_prd_rsp_i
+
+  /*
+  // To compressed predecoders: -- integrate into predecoders
+  // TODO
+  input  logic [31:0] instr_rdata_if_i,
+  output logic [31:0] instr_if_exp_o,
+  output logic        instr_if_exp_valid_o,
+  */
+
+
+);
+
+  /*
+  // TODO: Compressed Decoders
+  logic [31:0] unused_instr_rdata_if_i;
+  assign unused_instr_rdata_if_i = instr_rdata_if_i;
+  assign instr_if_exp_valid_o = 1'b0;
+  assign instr_if_exp_o = '0;
+  */
+
+  import acc_pkg::*;
+  localparam MaxNumRsp     = maxn(NumRsp, NumHier);
+  localparam HierAddrWidth = cf_math_pkg::idx_width(NumHier);
+  localparam AccAddrWidth  = cf_math_pkg::idx_width(MaxNumRsp);
+  localparam AddrWidth     = HierAddrWidth + AccAddrWidth;
+
+  logic [31:0] instr_rdata_id;
+
+  logic            acc_c_req_fifo_ready;
+  logic            acc_c_req_fifo_valid;
+  acc_c_req_chan_t acc_c_req_fifo_req;
+
+  logic [4:0] instr_rd;
+
+  logic [NumRspTot-1:0][31:0] acc_op_a;
+  logic [NumRspTot-1:0][31:0] acc_op_b;
+  logic [NumRspTot-1:0][31:0] acc_op_c;
+
+  logic [2:0] use_rs;
+
+  logic sources_valid;
+  logic rd_clean;
+
+  logic [NumRspTot-1:0] predecoder_accept_onehot;
+
+  for (genvar i=0; i<NumRspTot; i++) begin : gen_acc_predecoder_sig_assign
+    assign predecoder_accept_onehot[i]   = acc_prd_rsp_i[i].p_accept;
+    assign acc_prd_req_o[i].q_instr_data = acc_x_req_i.q.instr_data;
+  end
+
+  ////////////////////////
+  // Instruction Parser //
+  ////////////////////////
+
+  // Instruction data
+  assign instr_rdata_id   = acc_x_req_i.q.instr_data;
+
+  // Destination register
+  assign instr_rd = instr_rdata_id[11:7];
+
+  // operand muxes
+  for (genvar i=0; i<NumRspTot; i++) begin : gen_op_mux
+    always_comb begin
+      acc_op_a[i] = '0;
+      acc_op_b[i] = '0;
+      acc_op_c[i] = '0;
+      if (predecoder_accept_onehot[i]) begin
+        acc_op_a[i] = acc_prd_rsp_i[i].p_use_rs[0] ? acc_x_req_i.q.rs1 : '0;
+        acc_op_b[i] = acc_prd_rsp_i[i].p_use_rs[1] ? acc_x_req_i.q.rs2 : '0;
+        acc_op_c[i] = acc_prd_rsp_i[i].p_use_rs[2] ? acc_x_req_i.q.rs3 : '0;
+      end
+    end
+  end
+
+  /////////////////////
+  // Address Encoder //
+  /////////////////////
+
+  logic [NumHier-1:0]                   hier_onehot;
+  logic [HierAddrWidth-1:0]             hier_addr;
+  logic [NumHier-1:0][AccAddrWidth-1:0] acc_addr;
+  logic [NumHier-1:0][MaxNumRsp-1:0]    predecoder_accept_lvl;
+  // The first NumRsp[0] requests go to level 0
+  // The next NumRsp[1] requests go to level 1
+  // ...
+  //
+  for (genvar i=0; i<NumHier; i++) begin : gen_acc_addr
+    localparam SumNumRsp = sumn(NumRsp, i);
+
+    logic [NumRspTot-1:0] shift_predecoder_accept;
+    assign shift_predecoder_accept  = predecoder_accept_onehot >> SumNumRsp;
+    assign predecoder_accept_lvl[i] =
+        {{MaxNumRsp-NumRsp[i]{1'b0}}, shift_predecoder_accept[NumRsp[i]-1:0]};
+
+    // Accelerator address encoder
+    onehot_to_bin #(
+      .ONEHOT_WIDTH ( MaxNumRsp )
+    ) acc_addr_enc_i (
+      .onehot ( predecoder_accept_lvl[i] ),
+      .bin    ( acc_addr[i]              )
+    );
+    // Hierarchy level selsect
+    assign hier_onehot[i] = |predecoder_accept_lvl[i][NumRsp[i]-1:0];
+  end
+
+  // Hierarchy level encoder
+  onehot_to_bin #(
+    .ONEHOT_WIDTH(NumHier)
+  ) hier_addr_enc_i (
+    .onehot(hier_onehot),
+    .bin(hier_addr)
+  );
+
+  /////////////////////////////
+  // Assemble Request Struct //
+  /////////////////////////////
+
+  // Address
+  logic [AccAddrWidth-1:0] addr_lsb;
+  always_comb begin
+    addr_lsb = '0;
+    for (int i=0; i<NumHier; i++) begin
+      addr_lsb |= acc_addr[i];
+    end
+  end
+
+  assign acc_c_req_fifo_req.addr = {hier_addr, addr_lsb};
+
+  // Operands
+  always_comb begin
+    acc_c_req_fifo_req.data_arga = '0;
+    acc_c_req_fifo_req.data_argb = '0;
+    acc_c_req_fifo_req.data_argc = '0;
+    use_rs                       = '0;
+    acc_x_rsp_o.k.writeback      = '0;
+    for (int unsigned i=0; i<NumRspTot; i++) begin
+      acc_c_req_fifo_req.data_arga |= predecoder_accept_onehot[i] ? acc_op_a[i] : '0;
+      acc_c_req_fifo_req.data_argb |= predecoder_accept_onehot[i] ? acc_op_b[i] : '0;
+      acc_c_req_fifo_req.data_argc |= predecoder_accept_onehot[i] ? acc_op_c[i] : '0;
+      use_rs                       |=
+        predecoder_accept_onehot[i] ? acc_prd_rsp_i[i].p_use_rs    : '0;
+      acc_x_rsp_o.k.writeback      |=
+        predecoder_accept_onehot[i] ? acc_prd_rsp_i[i].p_writeback : '0;
+    end
+  end
+
+  // Instruction Data
+  assign acc_c_req_fifo_req.data_op = instr_rdata_id;
+  assign acc_c_req_fifo_req.id      = 1'b0;
+
+  //////////////////
+  // Flow Control //
+  //////////////////
+
+  // All source registers are ready if use_rs[i] == rs_valid[i] or ~use_rs[i];
+  assign sources_valid = ((use_rs ~^ acc_x_req_i.q.rs_valid) | ~use_rs) == '1;
+  // Destination registers are clean, if writeback expeted. (WAW-hazard)
+  assign rd_clean =
+      ((acc_x_rsp_o.k.writeback ~^ acc_x_req_i.q.rd_clean) | ~acc_x_rsp_o.k.writeback) == '1;
+
+  assign acc_x_rsp_o.k.accept = |predecoder_accept_onehot;
+  assign acc_c_req_fifo_valid =
+    acc_x_req_i.q_valid && sources_valid  && rd_clean && |predecoder_accept_onehot;
+  assign acc_x_rsp_o.q_ready  =
+    ~acc_x_rsp_o.k.accept || (sources_valid  && rd_clean && acc_c_req_fifo_ready);
+
+  // Forward accelerator response
+  assign acc_x_rsp_o.p       = acc_c_rsp_i.p;
+  assign acc_x_rsp_o.p_valid = acc_c_rsp_i.p_valid;
+  assign acc_c_req_o.p_ready = acc_x_req_i.p_ready;
+
+
+  /////////////////
+  // Output Fifo //
+  /////////////////
+
+  // To acc interconnect.
+  stream_fifo#(
+    .FALL_THROUGH ( 1'b1             ),
+    .DEPTH        ( 1                ),
+    .T            ( acc_c_req_chan_t )
+  ) acc_acc_c_req_out_reg (
+    .clk_i      ( clk_i                ),
+    .rst_ni     ( rst_ni               ),
+    .flush_i    ( 1'b0                 ),
+    .testmode_i ( 1'b0                 ),
+    .valid_i    ( acc_c_req_fifo_valid ),
+    .ready_o    ( acc_c_req_fifo_ready ),
+    .data_i     ( acc_c_req_fifo_req   ),
+    .valid_o    ( acc_c_req_o.q_valid  ),
+    .ready_i    ( acc_c_rsp_i.q_ready  ),
+    .data_o     ( acc_c_req_o.q        ),
+    .usage_o    ( /* unused */         )
+  );
+
+  // Sanity Checks
+  // pragma translate_off
+  `ifndef VERILATOR
+  assert property (@(posedge clk_i) $onehot0(predecoder_accept_onehot)) else
+      $error("Multiple accelerators accepeting request");
+  assert property (@(posedge clk_i) (acc_x_req_i.q_valid && !acc_x_rsp_o.q_ready)
+                                    |=> $stable(instr_rdata_id)) else
+      $error ("instr_rdata_id is unstable");
+  assert property (@(posedge clk_i) (acc_x_req_i.q_valid && !acc_x_rsp_o.q_ready)
+                                    |=> acc_x_req_i.q_valid) else
+      $error("acc_x_req_i.q_valid has been taken away without a ready");
+  assert property (@(posedge clk_i)
+      (acc_x_req_i.q_valid && acc_x_rsp_o.q_ready && acc_x_rsp_o.k.accept)
+          |-> sources_valid) else
+      $error("accepted offload request with invalid source registers");
+  `endif
+  // pragma translate_on
+
+endmodule
+
+module acc_adapter_intf #(
+  parameter int unsigned DataWidth       = 32,
+  parameter int          NumHier         = 3,
+  parameter int          NumRsp[NumHier] = '{4,2,2},
+  // Dependent parameter DO NOT OVERRIDE
+  parameter int          NumRspTot       = acc_pkg::sumn(NumRsp, NumHier)
+) (
+  input clk_i,
+  input rst_ni,
+
+  ACC_X_BUS   acc_x_mst,
+  ACC_C_BUS   acc_c_slv,
+  ACC_PRD_BUS acc_prd_mst [NumRspTot]
+);
+  import acc_pkg::*;
+
+  localparam MaxNumRsp     = maxn(NumRsp, NumHier);
+  localparam HierAddrWidth = cf_math_pkg::idx_width(NumHier);
+  localparam AccAddrWidth  = cf_math_pkg::idx_width(MaxNumRsp);
+  localparam AddrWidth     = HierAddrWidth + AccAddrWidth;
+
+  typedef logic [AddrWidth-1:0] addr_t;
+  typedef logic [DataWidth-1:0] data_t;
+  typedef logic [4:0]           id_t;
+
+  `ACC_X_TYPEDEF_ALL(acc_x, data_t, id_t)
+  `ACC_C_TYPEDEF_ALL(acc_c, addr_t, data_t, id_t)
+
+  acc_prd_req_t [NumRspTot-1:0] acc_prd_req;
+  acc_prd_rsp_t [NumRspTot-1:0] acc_prd_rsp;
+
+  acc_x_req_t acc_x_req;
+  acc_x_rsp_t acc_x_rsp;
+  acc_c_req_t acc_c_req;
+  acc_c_rsp_t acc_c_rsp;
+
+  acc_adapter #(
+    .DataWidth        ( DataWidth        ),
+    .NumHier          ( NumHier          ),
+    .NumRsp           ( NumRsp           ),
+    .acc_c_req_t      ( acc_c_req_t      ),
+    .acc_c_req_chan_t ( acc_c_req_chan_t ),
+    .acc_c_rsp_t      ( acc_c_rsp_t      ),
+    .acc_x_req_t      ( acc_x_req_t      ),
+    .acc_x_rsp_t      ( acc_x_rsp_t      )
+  ) acc_adapter_i (
+    .clk_i         ( clk_i       ),
+    .rst_ni        ( rst_ni      ),
+    .acc_x_req_i   ( acc_x_req   ),
+    .acc_x_rsp_o   ( acc_x_rsp   ),
+    .acc_c_req_o   ( acc_c_req   ),
+    .acc_c_rsp_i   ( acc_c_rsp   ),
+    .acc_prd_req_o ( acc_prd_req ),
+    .acc_prd_rsp_i ( acc_prd_rsp )
+  );
+
+  `ACC_C_ASSIGN_FROM_REQ(acc_c_slv, acc_c_req)
+  `ACC_C_ASSIGN_TO_RESP(acc_c_rsp, acc_c_slv)
+
+  `ACC_X_ASSIGN_TO_REQ(acc_x_req, acc_x_mst)
+  `ACC_X_ASSIGN_FROM_RESP(acc_x_mst, acc_x_rsp)
+
+  for (genvar i=0; i<NumRspTot; i++) begin : gen_acc_predecoder_intf_assign
+    `ACC_PRD_ASSIGN_FROM_REQ(acc_prd_mst[i], acc_prd_req[i])
+    `ACC_PRD_ASSIGN_TO_RESP(acc_prd_rsp[i], acc_prd_mst[i])
+  end
+
+endmodule

--- a/src/acc_interconnect.sv
+++ b/src/acc_interconnect.sv
@@ -20,6 +20,10 @@ module acc_interconnect #(
     parameter int          NumReq        = -1,
     // The number of rsponders.
     parameter int          NumRsp        = -1,
+    // Support for ternary operations (use rs3)
+    parameter bit          TernaryOps    = 0,
+    // Support for dual-writeback instructions
+    parameter bit          DualWriteback = 0,
     // Insert Pipeline register into request path
     parameter bit          RegisterReq   = 0,
     // Insert Pipeline register into response path
@@ -231,6 +235,10 @@ module acc_interconnect_intf #(
     parameter int          NumReq        = -1,
     // The number of rsponders.
     parameter int          NumRsp        = -1,
+    // Support for ternary operations (use rs3)
+    parameter bit          TernaryOps    = 0,
+    // Support for dual-writeback instructions
+    parameter bit          DualWriteback = 0,
     // Insert Pipeline register into request path
     parameter bit          RegisterReq   = 0,
     // Insert Pipeline register into response path
@@ -245,13 +253,15 @@ module acc_interconnect_intf #(
 );
 
   localparam int unsigned AddrWidth = HierAddrWidth + AccAddrWidth;
+  localparam int unsigned NumRs = TernaryOps ? 3 : 2;
+  localparam int unsigned NumWb = DualWriteback ? 2 : 1;
 
   typedef logic [DataWidth-1:0]  data_t;
   typedef logic [AddrWidth-1:0]  addr_t;
 
   // This generates some unused typedefs. still cleaner than invoking macros
   // separately.
-  `ACC_C_TYPEDEF_ALL(acc_c, addr_t, data_t)
+  `ACC_C_TYPEDEF_ALL(acc_c, addr_t, data_t, NumRs, NumWb)
 
   acc_c_req_t [NumReq-1:0] acc_c_slv_req;
   acc_c_rsp_t [NumReq-1:0] acc_c_slv_rsp;
@@ -269,6 +279,8 @@ module acc_interconnect_intf #(
       .HierLevel        ( HierLevel        ),
       .NumReq           ( NumReq           ),
       .NumRsp           ( NumRsp           ),
+      .TernaryOps       ( TernaryOps       ),
+      .DualWriteback    ( DualWriteback    ),
       .RegisterReq      ( RegisterReq      ),
       .RegisterRsp      ( RegisterRsp      ),
       .acc_c_req_t      ( acc_c_req_t      ),

--- a/src/acc_interconnect.sv
+++ b/src/acc_interconnect.sv
@@ -1,0 +1,318 @@
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Noam Gallmann <gnoam@live.com>
+//
+// Implements one hierarchy level of the accelerator interconnnect.
+
+`include "acc_interface/assign.svh"
+
+module acc_interconnect #(
+  // ISA bit width.
+  parameter int unsigned DataWidth     = 32,
+  // Hierarchy Address Portion
+  parameter int unsigned HierAddrWidth = -1,
+  // Accelerator Address Portion
+  parameter int unsigned AccAddrWidth  = -1,
+  // Hierarchy level
+  parameter int unsigned HierLevel     = -1,
+  // The number of requesters.
+  parameter int NumReq                 = -1,
+  // The number of rsponders.
+  parameter int NumRsp                 = -1,
+  // Insert Pipeline register into request path
+  parameter bit RegisterReq            = 0,
+  // Insert Pipeline register into response path
+  parameter bit RegisterRsp            = 0,
+
+  // Due to different widths of the ID field at the request master and slave
+  // side, we need separate struct typedefs.
+  // Ports connecting to the accelerator adapter, or lower level
+  // interconnects (master acc_c_slv ports_ feature Id signal width 1 (==1'b0).
+  // Ports connecting to the accelerator units feature id signal width
+  // 1+idx(NumRsp).
+  // Std Request Type : IdWidth = 1
+  parameter type acc_c_req_t          = logic,
+  // Std Request Payload Type
+  parameter type acc_c_req_chan_t     = logic,
+  // Std Response Type.
+  parameter type acc_c_rsp_t          = logic,
+  // Std Response Payload Type.
+  parameter type acc_c_rsp_chan_t     = logic,
+  // Extended Request Type.
+  parameter type acc_c_ext_req_t      = logic,
+  // Extended Request Payload Type
+  parameter type acc_c_ext_req_chan_t = logic,
+  // Extended Response Type
+  parameter type acc_c_ext_rsp_t      = logic,
+  // Extended Response Payload Type
+  parameter type acc_c_ext_rsp_chan_t = logic
+) (
+  input clk_i,
+  input rst_ni,
+
+  // From / To requesting entity
+  input  acc_c_req_t [NumReq-1:0] acc_c_slv_req_i,
+  output acc_c_rsp_t [NumReq-1:0] acc_c_slv_rsp_o,
+
+  // From / To next cluster level
+  output acc_c_req_t [NumReq-1:0] acc_c_mst_next_req_o,
+  input  acc_c_rsp_t [NumReq-1:0] acc_c_mst_next_rsp_i,
+
+  // From / To responding entity
+  output acc_c_ext_req_t [NumRsp-1:0] acc_c_mst_req_o,
+  input  acc_c_ext_rsp_t [NumRsp-1:0] acc_c_mst_rsp_i
+);
+
+  localparam int unsigned IdxWidth   = cf_math_pkg::idx_width(NumReq);
+  localparam int unsigned ExtIdWidth = 1 + IdxWidth;
+  localparam int unsigned AddrWidth  = HierAddrWidth + AccAddrWidth;
+
+  // Local xbar select signal width
+  localparam int unsigned OfflAddrWidth = cf_math_pkg::idx_width(NumRsp);
+
+  typedef logic [AddrWidth-1:0] addr_t;
+
+
+  acc_c_req_chan_t [NumReq-1:0]         mst_req_q_chan;
+  logic [NumReq-1:0][OfflAddrWidth-1:0] mst_req_q_addr;
+  logic [NumReq-1:0]                    mst_req_q_valid;
+  logic [NumReq-1:0]                    mst_req_p_ready;
+  // Hierarchy level address
+  logic [NumReq-1:0][HierAddrWidth-1:0] mst_req_q_level;
+
+  // this is mst_req_t, bc the payload does not change through the crossbar.
+  acc_c_req_chan_t [NumRsp-1:0] slv_req_q_chan;
+  logic [NumRsp-1:0]            slv_req_q_valid;
+  logic [NumRsp-1:0]            slv_req_p_ready;
+
+  logic [NumRsp-1:0][IdxWidth-1:0] sender_id; // assigned by crossbar.
+  logic [NumRsp-1:0][IdxWidth-1:0] receiver_id; // assigned by crossbar.
+
+  acc_c_rsp_chan_t [NumReq-1:0] mst_rsp_p_chan;
+  logic [NumReq-1:0]            mst_rsp_p_valid;
+  logic [NumReq-1:0]            mst_rsp_q_ready;
+
+  acc_c_rsp_chan_t [NumRsp-1:0] slv_rsp_p_chan;
+  logic [NumRsp-1:0]            slv_rsp_p_valid;
+  logic [NumRsp-1:0]            slv_rsp_q_ready;
+
+  for (genvar i=0; i<NumReq; i++) begin : gen_mst_req_assignment
+    assign mst_req_q_chan[i]  = acc_c_slv_req_i[i].q;
+    // Xbar Address
+    assign mst_req_q_addr[i]  = acc_c_slv_req_i[i].q.addr[OfflAddrWidth-1:0];
+    // Hierarchy level address
+    assign mst_req_q_level[i] = acc_c_slv_req_i[i].q.addr[AddrWidth-1:AccAddrWidth];
+  end
+
+  for (genvar i=0; i<NumRsp; i++) begin : gen_slv_req_assignment
+    // Extend ID signal at slave side
+    `ACC_C_ASSIGN_Q_SIGNALS(
+        assign, acc_c_mst_req_o[i].q, slv_req_q_chan[i], "id", {sender_id[i], 1'b0})
+
+    assign acc_c_mst_req_o[i].q_valid = slv_req_q_valid[i];
+    assign acc_c_mst_req_o[i].p_ready = slv_req_p_ready[i];
+  end
+
+  for (genvar i=0; i<NumRsp; i++) begin : gen_mst_rsp_assignment
+    // Discard upper bits of ID signal after xbar traversal.
+    `ACC_C_ASSIGN_P_SIGNALS(
+        assign, slv_rsp_p_chan[i], acc_c_mst_rsp_i[i].p, "id", 1'b0)
+    assign receiver_id[i]     = acc_c_mst_rsp_i[i].p.id[ExtIdWidth-1:1];
+    assign slv_rsp_p_valid[i] = acc_c_mst_rsp_i[i].p_valid;
+    assign slv_rsp_q_ready[i] = acc_c_mst_rsp_i[i].q_ready;
+  end
+
+  // Bypass this hierarchy level
+  for ( genvar i=0; i<NumReq; i++ ) begin : gen_bypass_path
+    // Offload path
+    assign acc_c_mst_next_req_o[i].q = acc_c_slv_req_i[i].q;
+    stream_demux #(
+      .N_OUP ( 2 )
+    ) offload_bypass_demux_i (
+      .inp_valid_i ( acc_c_slv_req_i[i].q_valid                            ),
+      .inp_ready_o ( acc_c_slv_rsp_o[i].q_ready                            ),
+      .oup_sel_i   ( mst_req_q_level[i] != HierLevel                       ),
+      .oup_valid_o ( {acc_c_mst_next_req_o[i].q_valid, mst_req_q_valid[i]} ),
+      .oup_ready_i ( {acc_c_mst_next_rsp_i[i].q_ready, mst_rsp_q_ready[i]} )
+    );
+
+    // Response Path
+    stream_arbiter #(
+      .DATA_T  ( acc_c_rsp_chan_t ),
+      .N_INP   ( 2                ),
+      .ARBITER ( "rr"             )
+    ) response_bypass_arbiter_i (
+      .clk_i       ( clk_i                                                 ),
+      .rst_ni      ( rst_ni                                                ),
+      .inp_data_i  ( {acc_c_mst_next_rsp_i[i].p, mst_rsp_p_chan[i]}        ),
+      .inp_valid_i ( {acc_c_mst_next_rsp_i[i].p_valid, mst_rsp_p_valid[i]} ),
+      .inp_ready_o ( {acc_c_mst_next_req_o[i].p_ready, mst_req_p_ready[i]} ),
+      .oup_data_o  ( acc_c_slv_rsp_o[i].p                                  ),
+      .oup_valid_o ( acc_c_slv_rsp_o[i].p_valid                            ),
+      .oup_ready_i ( acc_c_slv_req_i[i].p_ready                            )
+    );
+  end
+
+  // offload path Xbar
+  stream_xbar   #(
+    .NumInp      ( NumReq           ),
+    .NumOut      ( NumRsp           ),
+    .DataWidth   ( DataWidth        ),
+    .payload_t   ( acc_c_req_chan_t ),
+    .OutSpillReg ( RegisterReq      )
+  ) offload_xbar_i (
+    .clk_i   ( clk_i           ),
+    .rst_ni  ( rst_ni          ),
+    .flush_i ( 1'b0            ),
+    .rr_i    ( '0              ),
+    .data_i  ( mst_req_q_chan  ),
+    .sel_i   ( mst_req_q_addr  ),
+    .valid_i ( mst_req_q_valid ),
+    .ready_o ( mst_rsp_q_ready ),
+    .data_o  ( slv_req_q_chan  ),
+    .idx_o   ( sender_id       ),
+    .valid_o ( slv_req_q_valid ),
+    .ready_i ( slv_rsp_q_ready )
+  );
+
+  // response path Xbar
+  stream_xbar   #(
+    .NumInp      ( NumRsp           ),
+    .NumOut      ( NumReq           ),
+    .DataWidth   ( DataWidth        ),
+    .payload_t   ( acc_c_rsp_chan_t ),
+    .OutSpillReg ( RegisterRsp      )
+  ) response_xbar_i (
+    .clk_i   ( clk_i           ),
+    .rst_ni  ( rst_ni          ),
+    .flush_i ( 1'b0            ),
+    .rr_i    ( '0              ),
+    .data_i  ( slv_rsp_p_chan  ),
+    .sel_i   ( receiver_id     ),
+    .valid_i ( slv_rsp_p_valid ),
+    .ready_o ( slv_req_p_ready ),
+    .data_o  ( mst_rsp_p_chan  ),
+    .idx_o   (                 ),
+    .valid_o ( mst_rsp_p_valid ),
+    .ready_i ( mst_req_p_ready )
+  );
+
+  // Sanity Checks
+  // pragma translate_off
+  `ifndef VERILATOR
+  for (genvar i=0; i<NumReq; i++) begin : gen_req_fwd_asserts
+    assert property (@(posedge clk_i)
+        (acc_c_mst_next_req_o[i].q_valid)
+            |-> acc_c_mst_next_req_o[i].q.addr[AddrWidth-1:AccAddrWidth] > HierLevel) else
+        $error("Accelerator C request to level %0d bypassed interconnect level %0d.",
+            acc_c_mst_next_req_o[i].q.addr[AddrWidth-1:AccAddrWidth], HierLevel);
+  end
+
+  for (genvar i=0; i<NumRsp; i++) begin : gen_req_asserts
+    assert property (@(posedge clk_i)
+        (acc_c_mst_req_o[i].q_valid)
+            |-> acc_c_mst_req_o[i].q.addr[AddrWidth-1:AccAddrWidth] == HierLevel) else
+        $error("Accelerator C request to level %0d routed to interconnect level %0d.",
+            acc_c_mst_req_o[i].q.addr[AddrWidth-1:AccAddrWidth], HierLevel);
+  end
+  `endif
+  // pragma translate_on
+
+endmodule
+
+`include "acc_interface/typedef.svh"
+`include "acc_interface/assign.svh"
+
+module acc_interconnect_intf #(
+  // ISA bit width.
+  parameter int unsigned DataWidth     = 32,
+  // Hierarchy Address Portion
+  parameter int unsigned HierAddrWidth = -1,
+  // Accelerator Address Portion
+  parameter int unsigned AccAddrWidth  = -1,
+  // Hierarchy level
+  parameter int unsigned HierLevel     = -1,
+  // The number of requesters
+  parameter int NumReq                 = -1,
+  // The number of rsponders.
+  parameter int NumRsp                 = -1,
+  // Insert Pipeline register into request path
+  parameter bit RegisterReq            = 0,
+  // Insert Pipeline register into response path
+  parameter bit RegisterRsp            = 0
+) (
+  input clk_i,
+  input rst_ni,
+
+  ACC_C_BUS acc_c_slv       [NumReq],
+  ACC_C_BUS acc_c_mst_next  [NumReq],
+  ACC_C_BUS acc_c_mst       [NumRsp]
+);
+
+  localparam int unsigned IdxWidth   = cf_math_pkg::idx_width(NumReq);
+  localparam int unsigned ExtIdWidth = 1 + IdxWidth;
+  localparam int unsigned AddrWidth  = HierAddrWidth + AccAddrWidth;
+
+  typedef logic [DataWidth-1:0]  data_t;
+  typedef logic [AddrWidth-1:0]  addr_t;
+  typedef logic                  in_id_t;
+  typedef logic [ExtIdWidth-1:0] ext_id_t;
+
+  // This generates some unused typedefs. still cleaner than invoking macros
+  // separately.
+  `ACC_C_TYPEDEF_ALL(acc_c, addr_t, data_t, in_id_t)
+  `ACC_C_TYPEDEF_ALL(acc_c_ext, addr_t, data_t, ext_id_t)
+
+  acc_c_req_t [NumReq-1:0] acc_c_slv_req;
+  acc_c_rsp_t [NumReq-1:0] acc_c_slv_rsp;
+
+  acc_c_req_t [NumReq-1:0] acc_c_mst_next_req;
+  acc_c_rsp_t [NumReq-1:0] acc_c_mst_next_rsp;
+
+  acc_c_ext_req_t [NumRsp-1:0] acc_c_mst_req;
+  acc_c_ext_rsp_t [NumRsp-1:0] acc_c_mst_rsp;
+
+  acc_interconnect #(
+    .DataWidth            ( DataWidth            ),
+    .HierAddrWidth        ( HierAddrWidth        ),
+    .AccAddrWidth         ( AccAddrWidth         ),
+    .HierLevel            ( HierLevel            ),
+    .NumReq               ( NumReq               ),
+    .NumRsp               ( NumRsp               ),
+    .RegisterReq          ( RegisterReq          ),
+    .RegisterRsp          ( RegisterRsp          ),
+    .acc_c_req_t          ( acc_c_req_t          ),
+    .acc_c_req_chan_t     ( acc_c_req_chan_t     ),
+    .acc_c_rsp_t          ( acc_c_rsp_t          ),
+    .acc_c_rsp_chan_t     ( acc_c_rsp_chan_t     ),
+    .acc_c_ext_req_t      ( acc_c_ext_req_t      ),
+    .acc_c_ext_req_chan_t ( acc_c_ext_req_chan_t ),
+    .acc_c_ext_rsp_t      ( acc_c_ext_rsp_t      ),
+    .acc_c_ext_rsp_chan_t ( acc_c_ext_rsp_chan_t )
+  ) acc_interconnect_i (
+    .clk_i                ( clk_i              ),
+    .rst_ni               ( rst_ni             ),
+    .acc_c_slv_req_i      ( acc_c_slv_req      ),
+    .acc_c_slv_rsp_o      ( acc_c_slv_rsp      ),
+    .acc_c_mst_next_req_o ( acc_c_mst_next_req ),
+    .acc_c_mst_next_rsp_i ( acc_c_mst_next_rsp ),
+    .acc_c_mst_req_o      ( acc_c_mst_req      ),
+    .acc_c_mst_rsp_i      ( acc_c_mst_rsp      )
+  );
+
+  for (genvar i=0; i<NumReq; i++) begin : gen_slv_interface_assignement
+    `ACC_C_ASSIGN_TO_REQ(acc_c_slv_req[i], acc_c_slv[i])
+    `ACC_C_ASSIGN_FROM_RESP(acc_c_slv[i], acc_c_slv_rsp[i])
+  end
+  for (genvar i=0; i<NumRsp; i++) begin : gen_mst_interface_assignement
+    `ACC_C_ASSIGN_FROM_REQ(acc_c_mst[i], acc_c_mst_req[i])
+    `ACC_C_ASSIGN_TO_RESP(acc_c_mst_rsp[i], acc_c_mst[i])
+  end
+  for (genvar i=0; i<NumReq; i++) begin : gen_mst_next_interface_assignement
+    `ACC_C_ASSIGN_FROM_REQ(acc_c_mst_next[i], acc_c_mst_next_req[i])
+    `ACC_C_ASSIGN_TO_RESP(acc_c_mst_next_rsp[i], acc_c_mst_next[i])
+  end
+
+endmodule
+

--- a/src/acc_interconnect.sv
+++ b/src/acc_interconnect.sv
@@ -8,72 +8,72 @@
 `include "acc_interface/assign.svh"
 
 module acc_interconnect #(
-  // ISA bit width.
-  parameter int unsigned DataWidth     = 32,
-  // Hierarchy Address Portion
-  parameter int unsigned HierAddrWidth = -1,
-  // Accelerator Address Portion
-  parameter int unsigned AccAddrWidth  = -1,
-  // Hierarchy level
-  parameter int unsigned HierLevel     = -1,
-  // The number of requesters.
-  parameter int NumReq                 = -1,
-  // The number of rsponders.
-  parameter int NumRsp                 = -1,
-  // Insert Pipeline register into request path
-  parameter bit RegisterReq            = 0,
-  // Insert Pipeline register into response path
-  parameter bit RegisterRsp            = 0,
+    // ISA bit width.
+    parameter int unsigned DataWidth     = 32,
+    // Hierarchy Address Portion
+    parameter int unsigned HierAddrWidth = -1,
+    // Accelerator Address Portion
+    parameter int unsigned AccAddrWidth  = -1,
+    // Hierarchy level
+    parameter int unsigned HierLevel     = -1,
+    // The number of requesters.
+    parameter int          NumReq        = -1,
+    // The number of rsponders.
+    parameter int          NumRsp        = -1,
+    // Insert Pipeline register into request path
+    parameter bit          RegisterReq   = 0,
+    // Insert Pipeline register into response path
+    parameter bit          RegisterRsp   = 0,
 
-  // Due to different widths of the ID field at the request master and slave
-  // side, we need separate struct typedefs.
-  // Ports connecting to the accelerator adapter, or lower level
-  // interconnects (master acc_c_slv ports_ feature Id signal width 1 (==1'b0).
-  // Ports connecting to the accelerator units feature id signal width
-  // 1+idx(NumRsp).
-  // Std Request Type : IdWidth = 1
-  parameter type acc_c_req_t          = logic,
-  // Std Request Payload Type
-  parameter type acc_c_req_chan_t     = logic,
-  // Std Response Type.
-  parameter type acc_c_rsp_t          = logic,
-  // Std Response Payload Type.
-  parameter type acc_c_rsp_chan_t     = logic,
-  // Extended Request Type.
-  parameter type acc_c_ext_req_t      = logic,
-  // Extended Request Payload Type
-  parameter type acc_c_ext_req_chan_t = logic,
-  // Extended Response Type
-  parameter type acc_c_ext_rsp_t      = logic,
-  // Extended Response Payload Type
-  parameter type acc_c_ext_rsp_chan_t = logic
+    // Due to different widths of the ID field at the request master and slave
+    // side, we need separate struct typedefs.
+    // Ports connecting to the accelerator adapter, or lower level
+    // interconnects (master acc_c_slv ports_ feature Id signal width 1 (==1'b0).
+    // Ports connecting to the accelerator units feature id signal width
+    // 1+idx(NumRsp).
+    // Std Request Type : IdWidth = 1
+    parameter type acc_c_req_t          = logic,
+    // Std Request Payload Type
+    parameter type acc_c_req_chan_t     = logic,
+    // Std Response Type.
+    parameter type acc_c_rsp_t          = logic,
+    // Std Response Payload Type.
+    parameter type acc_c_rsp_chan_t     = logic,
+    // Extended Request Type.
+    parameter type acc_c_ext_req_t      = logic,
+    // Extended Request Payload Type
+    parameter type acc_c_ext_req_chan_t = logic,
+    // Extended Response Type
+    parameter type acc_c_ext_rsp_t      = logic,
+    // Extended Response Payload Type
+    parameter type acc_c_ext_rsp_chan_t = logic
 ) (
-  input clk_i,
-  input rst_ni,
+    input clk_i,
+    input rst_ni,
 
-  // From / To requesting entity
-  input  acc_c_req_t [NumReq-1:0] acc_c_slv_req_i,
-  output acc_c_rsp_t [NumReq-1:0] acc_c_slv_rsp_o,
+    // From / To requesting entity
+    input  acc_c_req_t [NumReq-1:0] acc_c_slv_req_i,
+    output acc_c_rsp_t [NumReq-1:0] acc_c_slv_rsp_o,
 
-  // From / To next cluster level
-  output acc_c_req_t [NumReq-1:0] acc_c_mst_next_req_o,
-  input  acc_c_rsp_t [NumReq-1:0] acc_c_mst_next_rsp_i,
+    // From / To next cluster level
+    output acc_c_req_t [NumReq-1:0] acc_c_mst_next_req_o,
+    input  acc_c_rsp_t [NumReq-1:0] acc_c_mst_next_rsp_i,
 
-  // From / To responding entity
-  output acc_c_ext_req_t [NumRsp-1:0] acc_c_mst_req_o,
-  input  acc_c_ext_rsp_t [NumRsp-1:0] acc_c_mst_rsp_i
+    // From / To responding entity
+    output acc_c_ext_req_t [NumRsp-1:0] acc_c_mst_req_o,
+    input  acc_c_ext_rsp_t [NumRsp-1:0] acc_c_mst_rsp_i
 );
 
-  localparam int unsigned IdxWidth   = cf_math_pkg::idx_width(NumReq);
+  localparam int unsigned IdxWidth = cf_math_pkg::idx_width(NumReq);
   localparam int unsigned ExtIdWidth = 1 + IdxWidth;
-  localparam int unsigned AddrWidth  = HierAddrWidth + AccAddrWidth;
+  localparam int unsigned AddrWidth = HierAddrWidth + AccAddrWidth;
 
   // Local xbar select signal width
   localparam int unsigned OfflAddrWidth = cf_math_pkg::idx_width(NumRsp);
 
   typedef logic [AddrWidth-1:0] addr_t;
 
-
+  // Master request: cross-bar in
   acc_c_req_chan_t [NumReq-1:0]         mst_req_q_chan;
   logic [NumReq-1:0][OfflAddrWidth-1:0] mst_req_q_addr;
   logic [NumReq-1:0]                    mst_req_q_valid;
@@ -81,23 +81,26 @@ module acc_interconnect #(
   // Hierarchy level address
   logic [NumReq-1:0][HierAddrWidth-1:0] mst_req_q_level;
 
-  // this is mst_req_t, bc the payload does not change through the crossbar.
+  // Slave rerequest: cross-bar out
+  // this is mst_req_t, bc the payload does not change through the cross-bar.
   acc_c_req_chan_t [NumRsp-1:0] slv_req_q_chan;
   logic [NumRsp-1:0]            slv_req_q_valid;
   logic [NumRsp-1:0]            slv_req_p_ready;
 
-  logic [NumRsp-1:0][IdxWidth-1:0] sender_id; // assigned by crossbar.
-  logic [NumRsp-1:0][IdxWidth-1:0] receiver_id; // assigned by crossbar.
+  logic [NumRsp-1:0][IdxWidth-1:0] sender_id;    // assigned by crossbar.
+  logic [NumRsp-1:0][IdxWidth-1:0] receiver_id;  // assigned by crossbar.
 
+  // Slave response: cross-bar in
+  acc_c_rsp_chan_t [NumRsp-1:0] slv_rsp_p_chan;
+  logic [NumRsp-1:0]            slv_rsp_p_valid;
+  logic [NumRsp-1:0]            slv_rsp_q_ready;
+  // Master response: cross-bar out
   acc_c_rsp_chan_t [NumReq-1:0] mst_rsp_p_chan;
   logic [NumReq-1:0]            mst_rsp_p_valid;
   logic [NumReq-1:0]            mst_rsp_q_ready;
 
-  acc_c_rsp_chan_t [NumRsp-1:0] slv_rsp_p_chan;
-  logic [NumRsp-1:0]            slv_rsp_p_valid;
-  logic [NumRsp-1:0]            slv_rsp_q_ready;
 
-  for (genvar i=0; i<NumReq; i++) begin : gen_mst_req_assignment
+  for (genvar i = 0; i < NumReq; i++) begin : gen_mst_req_assignment
     assign mst_req_q_chan[i]  = acc_c_slv_req_i[i].q;
     // Xbar Address
     assign mst_req_q_addr[i]  = acc_c_slv_req_i[i].q.addr[OfflAddrWidth-1:0];
@@ -105,118 +108,119 @@ module acc_interconnect #(
     assign mst_req_q_level[i] = acc_c_slv_req_i[i].q.addr[AddrWidth-1:AccAddrWidth];
   end
 
-  for (genvar i=0; i<NumRsp; i++) begin : gen_slv_req_assignment
+  for (genvar i = 0; i < NumRsp; i++) begin : gen_slv_req_assignment
     // Extend ID signal at slave side
-    `ACC_C_ASSIGN_Q_SIGNALS(
-        assign, acc_c_mst_req_o[i].q, slv_req_q_chan[i], "id", {sender_id[i], 1'b0})
+    `ACC_C_ASSIGN_Q_SIGNALS(assign, acc_c_mst_req_o[i].q, slv_req_q_chan[i], "id", {
+                            sender_id[i], 1'b0})
 
     assign acc_c_mst_req_o[i].q_valid = slv_req_q_valid[i];
     assign acc_c_mst_req_o[i].p_ready = slv_req_p_ready[i];
   end
 
-  for (genvar i=0; i<NumRsp; i++) begin : gen_mst_rsp_assignment
+  for (genvar i = 0; i < NumRsp; i++) begin : gen_mst_rsp_assignment
     // Discard upper bits of ID signal after xbar traversal.
-    `ACC_C_ASSIGN_P_SIGNALS(
-        assign, slv_rsp_p_chan[i], acc_c_mst_rsp_i[i].p, "id", 1'b0)
+    `ACC_C_ASSIGN_P_SIGNALS(assign, slv_rsp_p_chan[i], acc_c_mst_rsp_i[i].p, "id", 1'b0)
     assign receiver_id[i]     = acc_c_mst_rsp_i[i].p.id[ExtIdWidth-1:1];
     assign slv_rsp_p_valid[i] = acc_c_mst_rsp_i[i].p_valid;
     assign slv_rsp_q_ready[i] = acc_c_mst_rsp_i[i].q_ready;
   end
 
   // Bypass this hierarchy level
-  for ( genvar i=0; i<NumReq; i++ ) begin : gen_bypass_path
+  for (genvar i = 0; i < NumReq; i++) begin : gen_bypass_path
     // Offload path
     assign acc_c_mst_next_req_o[i].q = acc_c_slv_req_i[i].q;
     stream_demux #(
-      .N_OUP ( 2 )
+        .N_OUP ( 2 )
     ) offload_bypass_demux_i (
-      .inp_valid_i ( acc_c_slv_req_i[i].q_valid                            ),
-      .inp_ready_o ( acc_c_slv_rsp_o[i].q_ready                            ),
-      .oup_sel_i   ( mst_req_q_level[i] != HierLevel                       ),
-      .oup_valid_o ( {acc_c_mst_next_req_o[i].q_valid, mst_req_q_valid[i]} ),
-      .oup_ready_i ( {acc_c_mst_next_rsp_i[i].q_ready, mst_rsp_q_ready[i]} )
+        .inp_valid_i ( acc_c_slv_req_i[i].q_valid                            ),
+        .inp_ready_o ( acc_c_slv_rsp_o[i].q_ready                            ),
+        .oup_sel_i   ( mst_req_q_level[i] != HierLevel                       ),
+        .oup_valid_o ( {acc_c_mst_next_req_o[i].q_valid, mst_req_q_valid[i]} ),
+        .oup_ready_i ( {acc_c_mst_next_rsp_i[i].q_ready, mst_rsp_q_ready[i]} )
     );
 
     // Response Path
     stream_arbiter #(
-      .DATA_T  ( acc_c_rsp_chan_t ),
-      .N_INP   ( 2                ),
-      .ARBITER ( "rr"             )
+        .DATA_T  ( acc_c_rsp_chan_t ),
+        .N_INP   ( 2                ),
+        .ARBITER ( "rr"             )
     ) response_bypass_arbiter_i (
-      .clk_i       ( clk_i                                                 ),
-      .rst_ni      ( rst_ni                                                ),
-      .inp_data_i  ( {acc_c_mst_next_rsp_i[i].p, mst_rsp_p_chan[i]}        ),
-      .inp_valid_i ( {acc_c_mst_next_rsp_i[i].p_valid, mst_rsp_p_valid[i]} ),
-      .inp_ready_o ( {acc_c_mst_next_req_o[i].p_ready, mst_req_p_ready[i]} ),
-      .oup_data_o  ( acc_c_slv_rsp_o[i].p                                  ),
-      .oup_valid_o ( acc_c_slv_rsp_o[i].p_valid                            ),
-      .oup_ready_i ( acc_c_slv_req_i[i].p_ready                            )
+        .clk_i       ( clk_i                                                 ),
+        .rst_ni      ( rst_ni                                                ),
+        .inp_data_i  ( {acc_c_mst_next_rsp_i[i].p, mst_rsp_p_chan[i]}        ),
+        .inp_valid_i ( {acc_c_mst_next_rsp_i[i].p_valid, mst_rsp_p_valid[i]} ),
+        .inp_ready_o ( {acc_c_mst_next_req_o[i].p_ready, mst_req_p_ready[i]} ),
+        .oup_data_o  ( acc_c_slv_rsp_o[i].p                                  ),
+        .oup_valid_o ( acc_c_slv_rsp_o[i].p_valid                            ),
+        .oup_ready_i ( acc_c_slv_req_i[i].p_ready                            )
     );
   end
 
   // offload path Xbar
-  stream_xbar   #(
-    .NumInp      ( NumReq           ),
-    .NumOut      ( NumRsp           ),
-    .DataWidth   ( DataWidth        ),
-    .payload_t   ( acc_c_req_chan_t ),
-    .OutSpillReg ( RegisterReq      )
+  stream_xbar #(
+      .NumInp      ( NumReq           ),
+      .NumOut      ( NumRsp           ),
+      .DataWidth   ( DataWidth        ),
+      .payload_t   ( acc_c_req_chan_t ),
+      .OutSpillReg ( RegisterReq      )
   ) offload_xbar_i (
-    .clk_i   ( clk_i           ),
-    .rst_ni  ( rst_ni          ),
-    .flush_i ( 1'b0            ),
-    .rr_i    ( '0              ),
-    .data_i  ( mst_req_q_chan  ),
-    .sel_i   ( mst_req_q_addr  ),
-    .valid_i ( mst_req_q_valid ),
-    .ready_o ( mst_rsp_q_ready ),
-    .data_o  ( slv_req_q_chan  ),
-    .idx_o   ( sender_id       ),
-    .valid_o ( slv_req_q_valid ),
-    .ready_i ( slv_rsp_q_ready )
+      .clk_i   ( clk_i           ),
+      .rst_ni  ( rst_ni          ),
+      .flush_i ( 1'b0            ),
+      .rr_i    ( '0              ),
+      .data_i  ( mst_req_q_chan  ),
+      .sel_i   ( mst_req_q_addr  ),
+      .valid_i ( mst_req_q_valid ),
+      .ready_o ( mst_rsp_q_ready ),
+      .data_o  ( slv_req_q_chan  ),
+      .idx_o   ( sender_id       ),
+      .valid_o ( slv_req_q_valid ),
+      .ready_i ( slv_rsp_q_ready )
   );
 
   // response path Xbar
-  stream_xbar   #(
-    .NumInp      ( NumRsp           ),
-    .NumOut      ( NumReq           ),
-    .DataWidth   ( DataWidth        ),
-    .payload_t   ( acc_c_rsp_chan_t ),
-    .OutSpillReg ( RegisterRsp      )
+  stream_xbar #(
+      .NumInp      ( NumRsp           ),
+      .NumOut      ( NumReq           ),
+      .DataWidth   ( DataWidth        ),
+      .payload_t   ( acc_c_rsp_chan_t ),
+      .OutSpillReg ( RegisterRsp      )
   ) response_xbar_i (
-    .clk_i   ( clk_i           ),
-    .rst_ni  ( rst_ni          ),
-    .flush_i ( 1'b0            ),
-    .rr_i    ( '0              ),
-    .data_i  ( slv_rsp_p_chan  ),
-    .sel_i   ( receiver_id     ),
-    .valid_i ( slv_rsp_p_valid ),
-    .ready_o ( slv_req_p_ready ),
-    .data_o  ( mst_rsp_p_chan  ),
-    .idx_o   (                 ),
-    .valid_o ( mst_rsp_p_valid ),
-    .ready_i ( mst_req_p_ready )
+      .clk_i   ( clk_i           ),
+      .rst_ni  ( rst_ni          ),
+      .flush_i ( 1'b0            ),
+      .rr_i    ( '0              ),
+      .data_i  ( slv_rsp_p_chan  ),
+      .sel_i   ( receiver_id     ),
+      .valid_i ( slv_rsp_p_valid ),
+      .ready_o ( slv_req_p_ready ),
+      .data_o  ( mst_rsp_p_chan  ),
+      .idx_o   (                 ),
+      .valid_o ( mst_rsp_p_valid ),
+      .ready_i ( mst_req_p_ready )
   );
 
   // Sanity Checks
   // pragma translate_off
-  `ifndef VERILATOR
-  for (genvar i=0; i<NumReq; i++) begin : gen_req_fwd_asserts
+`ifndef VERILATOR
+  for (genvar i = 0; i < NumReq; i++) begin : gen_req_fwd_asserts
     assert property (@(posedge clk_i)
         (acc_c_mst_next_req_o[i].q_valid)
-            |-> acc_c_mst_next_req_o[i].q.addr[AddrWidth-1:AccAddrWidth] > HierLevel) else
-        $error("Accelerator C request to level %0d bypassed interconnect level %0d.",
-            acc_c_mst_next_req_o[i].q.addr[AddrWidth-1:AccAddrWidth], HierLevel);
+            |-> acc_c_mst_next_req_o[i].q.addr[AddrWidth-1:AccAddrWidth] > HierLevel)
+    else
+      $error("Accelerator C request to level %0d bypassed interconnect level %0d.",
+             acc_c_mst_next_req_o[i].q.addr[AddrWidth-1:AccAddrWidth], HierLevel);
   end
 
-  for (genvar i=0; i<NumRsp; i++) begin : gen_req_asserts
+  for (genvar i = 0; i < NumRsp; i++) begin : gen_req_asserts
     assert property (@(posedge clk_i)
         (acc_c_mst_req_o[i].q_valid)
-            |-> acc_c_mst_req_o[i].q.addr[AddrWidth-1:AccAddrWidth] == HierLevel) else
-        $error("Accelerator C request to level %0d routed to interconnect level %0d.",
-            acc_c_mst_req_o[i].q.addr[AddrWidth-1:AccAddrWidth], HierLevel);
+            |-> acc_c_mst_req_o[i].q.addr[AddrWidth-1:AccAddrWidth] == HierLevel)
+    else
+      $error("Accelerator C request to level %0d routed to interconnect level %0d.",
+             acc_c_mst_req_o[i].q.addr[AddrWidth-1:AccAddrWidth], HierLevel);
   end
-  `endif
+`endif
   // pragma translate_on
 
 endmodule
@@ -225,34 +229,34 @@ endmodule
 `include "acc_interface/assign.svh"
 
 module acc_interconnect_intf #(
-  // ISA bit width.
-  parameter int unsigned DataWidth     = 32,
-  // Hierarchy Address Portion
-  parameter int unsigned HierAddrWidth = -1,
-  // Accelerator Address Portion
-  parameter int unsigned AccAddrWidth  = -1,
-  // Hierarchy level
-  parameter int unsigned HierLevel     = -1,
-  // The number of requesters
-  parameter int NumReq                 = -1,
-  // The number of rsponders.
-  parameter int NumRsp                 = -1,
-  // Insert Pipeline register into request path
-  parameter bit RegisterReq            = 0,
-  // Insert Pipeline register into response path
-  parameter bit RegisterRsp            = 0
+    // ISA bit width.
+    parameter int unsigned DataWidth     = 32,
+    // Hierarchy Address Portion
+    parameter int unsigned HierAddrWidth = -1,
+    // Accelerator Address Portion
+    parameter int unsigned AccAddrWidth  = -1,
+    // Hierarchy level
+    parameter int unsigned HierLevel     = -1,
+    // The number of requesters
+    parameter int          NumReq        = -1,
+    // The number of rsponders.
+    parameter int          NumRsp        = -1,
+    // Insert Pipeline register into request path
+    parameter bit          RegisterReq   = 0,
+    // Insert Pipeline register into response path
+    parameter bit          RegisterRsp   = 0
 ) (
-  input clk_i,
-  input rst_ni,
+    input clk_i,
+    input rst_ni,
 
-  ACC_C_BUS acc_c_slv       [NumReq],
-  ACC_C_BUS acc_c_mst_next  [NumReq],
-  ACC_C_BUS acc_c_mst       [NumRsp]
+    ACC_C_BUS acc_c_slv     [NumReq],
+    ACC_C_BUS acc_c_mst_next[NumReq],
+    ACC_C_BUS acc_c_mst     [NumRsp]
 );
 
-  localparam int unsigned IdxWidth   = cf_math_pkg::idx_width(NumReq);
+  localparam int unsigned IdxWidth = cf_math_pkg::idx_width(NumReq);
   localparam int unsigned ExtIdWidth = 1 + IdxWidth;
-  localparam int unsigned AddrWidth  = HierAddrWidth + AccAddrWidth;
+  localparam int unsigned AddrWidth = HierAddrWidth + AccAddrWidth;
 
   typedef logic [DataWidth-1:0]  data_t;
   typedef logic [AddrWidth-1:0]  addr_t;
@@ -274,45 +278,44 @@ module acc_interconnect_intf #(
   acc_c_ext_rsp_t [NumRsp-1:0] acc_c_mst_rsp;
 
   acc_interconnect #(
-    .DataWidth            ( DataWidth            ),
-    .HierAddrWidth        ( HierAddrWidth        ),
-    .AccAddrWidth         ( AccAddrWidth         ),
-    .HierLevel            ( HierLevel            ),
-    .NumReq               ( NumReq               ),
-    .NumRsp               ( NumRsp               ),
-    .RegisterReq          ( RegisterReq          ),
-    .RegisterRsp          ( RegisterRsp          ),
-    .acc_c_req_t          ( acc_c_req_t          ),
-    .acc_c_req_chan_t     ( acc_c_req_chan_t     ),
-    .acc_c_rsp_t          ( acc_c_rsp_t          ),
-    .acc_c_rsp_chan_t     ( acc_c_rsp_chan_t     ),
-    .acc_c_ext_req_t      ( acc_c_ext_req_t      ),
-    .acc_c_ext_req_chan_t ( acc_c_ext_req_chan_t ),
-    .acc_c_ext_rsp_t      ( acc_c_ext_rsp_t      ),
-    .acc_c_ext_rsp_chan_t ( acc_c_ext_rsp_chan_t )
+      .DataWidth            ( DataWidth            ),
+      .HierAddrWidth        ( HierAddrWidth        ),
+      .AccAddrWidth         ( AccAddrWidth         ),
+      .HierLevel            ( HierLevel            ),
+      .NumReq               ( NumReq               ),
+      .NumRsp               ( NumRsp               ),
+      .RegisterReq          ( RegisterReq          ),
+      .RegisterRsp          ( RegisterRsp          ),
+      .acc_c_req_t          ( acc_c_req_t          ),
+      .acc_c_req_chan_t     ( acc_c_req_chan_t     ),
+      .acc_c_rsp_t          ( acc_c_rsp_t          ),
+      .acc_c_rsp_chan_t     ( acc_c_rsp_chan_t     ),
+      .acc_c_ext_req_t      ( acc_c_ext_req_t      ),
+      .acc_c_ext_req_chan_t ( acc_c_ext_req_chan_t ),
+      .acc_c_ext_rsp_t      ( acc_c_ext_rsp_t      ),
+      .acc_c_ext_rsp_chan_t ( acc_c_ext_rsp_chan_t )
   ) acc_interconnect_i (
-    .clk_i                ( clk_i              ),
-    .rst_ni               ( rst_ni             ),
-    .acc_c_slv_req_i      ( acc_c_slv_req      ),
-    .acc_c_slv_rsp_o      ( acc_c_slv_rsp      ),
-    .acc_c_mst_next_req_o ( acc_c_mst_next_req ),
-    .acc_c_mst_next_rsp_i ( acc_c_mst_next_rsp ),
-    .acc_c_mst_req_o      ( acc_c_mst_req      ),
-    .acc_c_mst_rsp_i      ( acc_c_mst_rsp      )
+      .clk_i                ( clk_i              ),
+      .rst_ni               ( rst_ni             ),
+      .acc_c_slv_req_i      ( acc_c_slv_req      ),
+      .acc_c_slv_rsp_o      ( acc_c_slv_rsp      ),
+      .acc_c_mst_next_req_o ( acc_c_mst_next_req ),
+      .acc_c_mst_next_rsp_i ( acc_c_mst_next_rsp ),
+      .acc_c_mst_req_o      ( acc_c_mst_req      ),
+      .acc_c_mst_rsp_i      ( acc_c_mst_rsp      )
   );
 
-  for (genvar i=0; i<NumReq; i++) begin : gen_slv_interface_assignement
+  for (genvar i = 0; i < NumReq; i++) begin : gen_slv_interface_assignement
     `ACC_C_ASSIGN_TO_REQ(acc_c_slv_req[i], acc_c_slv[i])
     `ACC_C_ASSIGN_FROM_RESP(acc_c_slv[i], acc_c_slv_rsp[i])
   end
-  for (genvar i=0; i<NumRsp; i++) begin : gen_mst_interface_assignement
+  for (genvar i = 0; i < NumRsp; i++) begin : gen_mst_interface_assignement
     `ACC_C_ASSIGN_FROM_REQ(acc_c_mst[i], acc_c_mst_req[i])
     `ACC_C_ASSIGN_TO_RESP(acc_c_mst_rsp[i], acc_c_mst[i])
   end
-  for (genvar i=0; i<NumReq; i++) begin : gen_mst_next_interface_assignement
+  for (genvar i = 0; i < NumReq; i++) begin : gen_mst_next_interface_assignement
     `ACC_C_ASSIGN_FROM_REQ(acc_c_mst_next[i], acc_c_mst_next_req[i])
     `ACC_C_ASSIGN_TO_RESP(acc_c_mst_next_rsp[i], acc_c_mst_next[i])
   end
 
 endmodule
-

--- a/src/acc_intf.sv
+++ b/src/acc_intf.sv
@@ -21,14 +21,11 @@ interface ACC_C_BUS #(
     // ISA bit width
     parameter int unsigned DataWidth = 32,
     // Address Width
-    parameter int          AddrWidth = -1,
-    // ID Width
-    parameter int          IdWidth   = -1
+    parameter int          AddrWidth = -1
 );
 
   typedef logic [DataWidth-1:0] data_t;
   typedef logic [AddrWidth-1:0] addr_t;
-  typedef logic [IdWidth-1:0]   id_t;
 
   // Request channel (Q).
   addr_t        q_addr;
@@ -36,7 +33,7 @@ interface ACC_C_BUS #(
   data_t        q_data_arga;
   data_t        q_data_argb;
   data_t        q_data_argc;
-  id_t          q_id;
+  logic  [31:0] q_hart_id;
   logic         q_valid;
   logic         q_ready;
 
@@ -44,20 +41,20 @@ interface ACC_C_BUS #(
   data_t        p_data0;
   data_t        p_data1;
   logic         p_dual_writeback;
-  id_t          p_id;
+  logic  [31:0] p_hart_id;
   logic  [ 4:0] p_rd;
   logic         p_error;
   logic         p_valid;
   logic         p_ready;
 
   modport in(
-      input q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
-      output q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+      input q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_hart_id, q_valid, p_ready,
+      output q_ready, p_data0, p_data1, p_dual_writeback, p_hart_id, p_rd, p_error, p_valid
   );
 
   modport out(
-      output q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
-      input q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+      output q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_hart_id, q_valid, p_ready,
+      input q_ready, p_data0, p_data1, p_dual_writeback, p_hart_id, p_rd, p_error, p_valid
   );
 
 endinterface
@@ -66,16 +63,13 @@ interface ACC_C_BUS_DV #(
     // ISA bit width
     parameter int unsigned DataWidth = 32,
     // Address Width
-    parameter int          AddrWidth = -1,
-    // ID Width
-    parameter int          IdWidth   = -1
+    parameter int          AddrWidth = -1
 ) (
     input logic clk_i
 );
 
   typedef logic [DataWidth-1:0] data_t;
   typedef logic [AddrWidth-1:0] addr_t;
-  typedef logic [IdWidth-1:0] id_t;
 
   // Request channel (Q).
   addr_t        q_addr;
@@ -83,7 +77,7 @@ interface ACC_C_BUS_DV #(
   data_t        q_data_arga;
   data_t        q_data_argb;
   data_t        q_data_argc;
-  id_t          q_id;
+  logic  [31:0] q_hart_id;
   logic         q_valid;
   logic         q_ready;
 
@@ -91,25 +85,25 @@ interface ACC_C_BUS_DV #(
   data_t        p_data0;
   data_t        p_data1;
   logic         p_dual_writeback;
-  id_t          p_id;
+  logic  [31:0] p_hart_id;
   logic  [ 4:0] p_rd;
   logic         p_error;
   logic         p_valid;
   logic         p_ready;
 
   modport in(
-      input q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
-      output q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+      input q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_hart_id, q_valid, p_ready,
+      output q_ready, p_data0, p_data1, p_dual_writeback, p_hart_id, p_rd, p_error, p_valid
   );
 
   modport out(
-      output q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
-      input q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+      output q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_hart_id, q_valid, p_ready,
+      input q_ready, p_data0, p_data1, p_dual_writeback, p_hart_id, p_rd, p_error, p_valid
   );
 
   modport monitor(
-      input q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
-      input q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+      input q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_hart_id, q_valid, p_ready,
+      input q_ready, p_data0, p_data1, p_dual_writeback, p_hart_id, p_rd, p_error, p_valid
   );
 
   // pragma translate_off
@@ -119,13 +113,13 @@ interface ACC_C_BUS_DV #(
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data_arga)));
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data_argb)));
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data_argc)));
-  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_id)));
+  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_hart_id)));
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> q_valid));
 
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_data0)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_data1)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_dual_writeback)));
-  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_id)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_hart_id)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_rd)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_error)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> p_valid));
@@ -258,7 +252,6 @@ interface ACC_X_BUS_DV #(
 endinterface
 
 interface ACC_PRD_BUS;
-
 
   logic [31:0] q_instr_data;
   logic [ 1:0] p_writeback;

--- a/src/acc_intf.sv
+++ b/src/acc_intf.sv
@@ -1,0 +1,308 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Noam Gallmann <gnoam@live.com>
+
+// Accelerator Interface
+//
+// This interface provides two channels, one for requests and one for
+// responses. Both channels have a valid/ready handshake. The sender sets the
+// channel signals and pulls valid high. Once pulled high, valid must remain
+// high and none of the signals may change. The transaction completes when both
+// valid and ready are high. Valid must not depend on ready.
+// The requester can offload any RISC-V instruction together with its operands
+// and destination register address.
+// Not all offloaded instructions necessarily result in a response. The
+// offloading entity must be aware if a write-back is to be expected.
+// For further details see docs/index.md.
+
+interface ACC_C_BUS #(
+  // ISA bit width
+  parameter int unsigned DataWidth = 32,
+  // Address Width
+  parameter int          AddrWidth = -1,
+  // ID Width
+  parameter int          IdWidth   = -1
+);
+
+  typedef logic [DataWidth-1:0] data_t;
+  typedef logic [AddrWidth-1:0] addr_t;
+  typedef logic [IdWidth-1:0]   id_t;
+
+  // Request channel (Q).
+  addr_t       q_addr;
+  logic [31:0] q_data_op;
+  data_t       q_data_arga;
+  data_t       q_data_argb;
+  data_t       q_data_argc;
+  id_t         q_id;
+  logic        q_valid;
+  logic        q_ready;
+
+  // Response Channel (P).
+  data_t      p_data0;
+  data_t      p_data1;
+  logic       p_dual_writeback;
+  id_t        p_id;
+  logic [4:0] p_rd;
+  logic       p_error;
+  logic       p_valid;
+  logic       p_ready;
+
+  modport in (
+    input  q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
+    output q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+  );
+
+  modport out (
+    output q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
+    input  q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+  );
+
+endinterface
+
+interface ACC_C_BUS_DV #(
+  // ISA bit width
+  parameter int unsigned DataWidth = 32,
+  // Address Width
+  parameter int          AddrWidth = -1,
+  // ID Width
+  parameter int          IdWidth   = -1
+) (
+  input logic clk_i
+);
+
+  typedef logic [DataWidth-1:0] data_t;
+  typedef logic [AddrWidth-1:0] addr_t;
+  typedef logic [IdWidth-1:0]   id_t;
+
+  // Request channel (Q).
+  addr_t       q_addr;
+  logic [31:0] q_data_op;
+  data_t       q_data_arga;
+  data_t       q_data_argb;
+  data_t       q_data_argc;
+  id_t         q_id;
+  logic        q_valid;
+  logic        q_ready;
+
+  // Response Channel (P).
+  data_t      p_data0;
+  data_t      p_data1;
+  logic       p_dual_writeback;
+  id_t        p_id;
+  logic [4:0] p_rd;
+  logic       p_error;
+  logic       p_valid;
+  logic       p_ready;
+
+  modport in (
+    input  q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
+    output q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+  );
+
+  modport out (
+    output q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
+    input  q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+  );
+
+  modport monitor (
+    input  q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
+    input  q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+  );
+
+  // pragma translate_off
+  `ifndef VERILATOR
+  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_addr)));
+  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data_op)));
+  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data_arga)));
+  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data_argb)));
+  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data_argc)));
+  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_id)));
+  assert property (@(posedge clk_i) (q_valid && !q_ready |=> q_valid));
+
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_data0)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_data1)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_dual_writeback)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_id)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_rd)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_error)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> p_valid));
+  `endif
+  // pragma translate_on
+
+endinterface
+
+interface ACC_X_BUS #(
+  // ISA bit Width
+  parameter int DataWidth = 32
+);
+
+  typedef logic [DataWidth-1:0] data_t;
+
+  // Request Channel (Q)
+  logic [31:0] q_instr_data;
+  data_t       q_rs1;
+  data_t       q_rs2;
+  data_t       q_rs3;
+  logic [2:0]  q_rs_valid;
+  logic [1:0]  q_rd_clean;
+  logic        q_valid;
+
+  // Acknowledge Channel (K)
+  logic       k_accept;
+  logic [1:0] k_writeback;
+  logic       q_ready;
+
+  // Response Channel (P)
+  data_t      p_data0;
+  data_t      p_data1;
+  logic       p_dual_writeback;
+  logic [4:0] p_rd;
+  logic       p_error;
+  logic       p_valid;
+  logic       p_ready;
+
+  modport in (
+    input q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+    output k_accept, k_writeback, q_ready,
+    output p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+  );
+
+  modport out (
+    output q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+    input k_accept, k_writeback, q_ready,
+    input p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+  );
+
+
+endinterface
+
+interface ACC_X_BUS_DV #(
+  // ISA bit Width
+  parameter int DataWidth = 32
+
+) (
+  input clk_i
+);
+
+  typedef logic [DataWidth-1:0] data_t;
+
+  // Request Channel (Q)
+  logic [31:0] q_instr_data;
+  data_t       q_rs1;
+  data_t       q_rs2;
+  data_t       q_rs3;
+  logic [2:0]  q_rs_valid;
+  logic [1:0]  q_rd_clean;
+  logic        q_valid;
+
+  // Acknowledge Channel (K)
+  logic       k_accept;
+  logic [1:0] k_writeback;
+  logic       q_ready;
+
+  // Response Channel (P)
+  data_t      p_data0;
+  data_t      p_data1;
+  logic       p_error;
+  logic [4:0] p_rd;
+  logic       p_dual_writeback;
+  logic       p_valid;
+  logic       p_ready;
+
+  modport in (
+    input q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+    output k_accept, k_writeback, q_ready,
+    output p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+  );
+
+  modport out (
+    output q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+    input k_accept, k_writeback, q_ready,
+    input p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+  );
+
+  modport monitor (
+    output q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+    input k_accept, k_writeback, q_ready,
+    input p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+  );
+
+  // pragma translate_off
+  `ifndef VERILATOR
+
+  // q channel
+  assert property (@(posedge clk_i) (q_valid && !q_ready |=> q_valid));
+  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_instr_data)));
+
+  assert property (@(posedge clk_i) (q_valid && q_rs_valid[0] && !q_ready |=> q_rs_valid[0]));
+  assert property (@(posedge clk_i) (q_valid && q_rs_valid[1] && !q_ready |=> q_rs_valid[1]));
+  assert property (@(posedge clk_i) (q_valid && q_rs_valid[2] && !q_ready |=> q_rs_valid[2]));
+  assert property (@(posedge clk_i) (q_valid && q_rs_valid[0] && !q_ready |=> $stable(q_rs1)));
+  assert property (@(posedge clk_i) (q_valid && q_rs_valid[1] && !q_ready |=> $stable(q_rs2)));
+  assert property (@(posedge clk_i) (q_valid && q_rs_valid[2] && !q_ready |=> $stable(q_rs3)));
+
+  assert property (@(posedge clk_i)
+      (q_valid && q_ready |-> ((k_writeback ~^ q_rd_clean) | ~k_writeback) == '1));
+
+  // p channel
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_data0)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_data1)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_dual_writeback)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_rd)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_error)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> p_valid));
+
+  `endif
+  // pragma translate_on
+endinterface
+
+interface ACC_PRD_BUS;
+
+
+  logic [31:0] q_instr_data;
+  logic [1:0]  p_writeback;
+  logic [2:0]  p_use_rs;
+  logic        p_accept;
+
+  modport in (
+    input  q_instr_data,
+    output p_writeback, p_use_rs, p_accept
+  );
+
+  modport out (
+    output q_instr_data,
+    input p_writeback, p_use_rs, p_accept
+  );
+
+endinterface
+
+interface ACC_PRD_BUS_DV (
+  input clk_i
+);
+
+  logic [31:0] q_instr_data;
+  logic [1:0]  p_writeback;
+  logic [2:0]  p_use_rs;
+  logic        p_accept;
+
+  modport in (
+    input  q_instr_data,
+    output p_writeback, p_use_rs, p_accept
+  );
+
+  modport out (
+    output q_instr_data,
+    input p_writeback, p_use_rs, p_accept
+  );
+
+  modport monitor (
+    input  q_instr_data,
+    input p_writeback, p_use_rs, p_accept
+  );
+
+  // No asserts. This interface is completely combinational
+
+endinterface

--- a/src/acc_intf.sv
+++ b/src/acc_intf.sv
@@ -18,12 +18,12 @@
 // For further details see docs/index.md.
 
 interface ACC_C_BUS #(
-  // ISA bit width
-  parameter int unsigned DataWidth = 32,
-  // Address Width
-  parameter int          AddrWidth = -1,
-  // ID Width
-  parameter int          IdWidth   = -1
+    // ISA bit width
+    parameter int unsigned DataWidth = 32,
+    // Address Width
+    parameter int          AddrWidth = -1,
+    // ID Width
+    parameter int          IdWidth   = -1
 );
 
   typedef logic [DataWidth-1:0] data_t;
@@ -31,89 +31,89 @@ interface ACC_C_BUS #(
   typedef logic [IdWidth-1:0]   id_t;
 
   // Request channel (Q).
-  addr_t       q_addr;
-  logic [31:0] q_data_op;
-  data_t       q_data_arga;
-  data_t       q_data_argb;
-  data_t       q_data_argc;
-  id_t         q_id;
-  logic        q_valid;
-  logic        q_ready;
+  addr_t        q_addr;
+  logic  [31:0] q_data_op;
+  data_t        q_data_arga;
+  data_t        q_data_argb;
+  data_t        q_data_argc;
+  id_t          q_id;
+  logic         q_valid;
+  logic         q_ready;
 
   // Response Channel (P).
-  data_t      p_data0;
-  data_t      p_data1;
-  logic       p_dual_writeback;
-  id_t        p_id;
-  logic [4:0] p_rd;
-  logic       p_error;
-  logic       p_valid;
-  logic       p_ready;
+  data_t        p_data0;
+  data_t        p_data1;
+  logic         p_dual_writeback;
+  id_t          p_id;
+  logic  [ 4:0] p_rd;
+  logic         p_error;
+  logic         p_valid;
+  logic         p_ready;
 
-  modport in (
-    input  q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
-    output q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+  modport in(
+      input q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
+      output q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
   );
 
-  modport out (
-    output q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
-    input  q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+  modport out(
+      output q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
+      input q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
   );
 
 endinterface
 
 interface ACC_C_BUS_DV #(
-  // ISA bit width
-  parameter int unsigned DataWidth = 32,
-  // Address Width
-  parameter int          AddrWidth = -1,
-  // ID Width
-  parameter int          IdWidth   = -1
+    // ISA bit width
+    parameter int unsigned DataWidth = 32,
+    // Address Width
+    parameter int          AddrWidth = -1,
+    // ID Width
+    parameter int          IdWidth   = -1
 ) (
-  input logic clk_i
+    input logic clk_i
 );
 
   typedef logic [DataWidth-1:0] data_t;
   typedef logic [AddrWidth-1:0] addr_t;
-  typedef logic [IdWidth-1:0]   id_t;
+  typedef logic [IdWidth-1:0] id_t;
 
   // Request channel (Q).
-  addr_t       q_addr;
-  logic [31:0] q_data_op;
-  data_t       q_data_arga;
-  data_t       q_data_argb;
-  data_t       q_data_argc;
-  id_t         q_id;
-  logic        q_valid;
-  logic        q_ready;
+  addr_t        q_addr;
+  logic  [31:0] q_data_op;
+  data_t        q_data_arga;
+  data_t        q_data_argb;
+  data_t        q_data_argc;
+  id_t          q_id;
+  logic         q_valid;
+  logic         q_ready;
 
   // Response Channel (P).
-  data_t      p_data0;
-  data_t      p_data1;
-  logic       p_dual_writeback;
-  id_t        p_id;
-  logic [4:0] p_rd;
-  logic       p_error;
-  logic       p_valid;
-  logic       p_ready;
+  data_t        p_data0;
+  data_t        p_data1;
+  logic         p_dual_writeback;
+  id_t          p_id;
+  logic  [ 4:0] p_rd;
+  logic         p_error;
+  logic         p_valid;
+  logic         p_ready;
 
-  modport in (
-    input  q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
-    output q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+  modport in(
+      input q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
+      output q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
   );
 
-  modport out (
-    output q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
-    input  q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+  modport out(
+      output q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
+      input q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
   );
 
-  modport monitor (
-    input  q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
-    input  q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
+  modport monitor(
+      input q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_id, q_valid, p_ready,
+      input q_ready, p_data0, p_data1, p_dual_writeback, p_id, p_rd, p_error, p_valid
   );
 
   // pragma translate_off
-  `ifndef VERILATOR
+`ifndef VERILATOR
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_addr)));
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data_op)));
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data_arga)));
@@ -129,110 +129,109 @@ interface ACC_C_BUS_DV #(
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_rd)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_error)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> p_valid));
-  `endif
+`endif
   // pragma translate_on
 
 endinterface
 
 interface ACC_X_BUS #(
-  // ISA bit Width
-  parameter int DataWidth = 32
+    // ISA bit Width
+    parameter int DataWidth = 32
 );
 
   typedef logic [DataWidth-1:0] data_t;
 
   // Request Channel (Q)
-  logic [31:0] q_instr_data;
-  data_t       q_rs1;
-  data_t       q_rs2;
-  data_t       q_rs3;
-  logic [2:0]  q_rs_valid;
-  logic [1:0]  q_rd_clean;
-  logic        q_valid;
+  logic  [31:0] q_instr_data;
+  data_t        q_rs1;
+  data_t        q_rs2;
+  data_t        q_rs3;
+  logic  [ 2:0] q_rs_valid;
+  logic  [ 1:0] q_rd_clean;
+  logic         q_valid;
 
   // Acknowledge Channel (K)
-  logic       k_accept;
-  logic [1:0] k_writeback;
-  logic       q_ready;
+  logic         k_accept;
+  logic  [ 1:0] k_writeback;
+  logic         q_ready;
 
   // Response Channel (P)
-  data_t      p_data0;
-  data_t      p_data1;
-  logic       p_dual_writeback;
-  logic [4:0] p_rd;
-  logic       p_error;
-  logic       p_valid;
-  logic       p_ready;
+  data_t        p_data0;
+  data_t        p_data1;
+  logic         p_dual_writeback;
+  logic  [ 4:0] p_rd;
+  logic         p_error;
+  logic         p_valid;
+  logic         p_ready;
 
-  modport in (
-    input q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
-    output k_accept, k_writeback, q_ready,
-    output p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+  modport in(
+      input q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+      output k_accept, k_writeback, q_ready,
+      output p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
   );
 
-  modport out (
-    output q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
-    input k_accept, k_writeback, q_ready,
-    input p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+  modport out(
+      output q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+      input k_accept, k_writeback, q_ready,
+      input p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
   );
 
 
 endinterface
 
 interface ACC_X_BUS_DV #(
-  // ISA bit Width
-  parameter int DataWidth = 32
+    // ISA bit Width
+    parameter int DataWidth = 32
 
 ) (
-  input clk_i
+    input clk_i
 );
 
   typedef logic [DataWidth-1:0] data_t;
 
   // Request Channel (Q)
-  logic [31:0] q_instr_data;
-  data_t       q_rs1;
-  data_t       q_rs2;
-  data_t       q_rs3;
-  logic [2:0]  q_rs_valid;
-  logic [1:0]  q_rd_clean;
-  logic        q_valid;
+  logic  [31:0] q_instr_data;
+  data_t        q_rs1;
+  data_t        q_rs2;
+  data_t        q_rs3;
+  logic  [ 2:0] q_rs_valid;
+  logic  [ 1:0] q_rd_clean;
+  logic         q_valid;
 
   // Acknowledge Channel (K)
-  logic       k_accept;
-  logic [1:0] k_writeback;
-  logic       q_ready;
+  logic         k_accept;
+  logic  [ 1:0] k_writeback;
+  logic         q_ready;
 
   // Response Channel (P)
-  data_t      p_data0;
-  data_t      p_data1;
-  logic       p_error;
-  logic [4:0] p_rd;
-  logic       p_dual_writeback;
-  logic       p_valid;
-  logic       p_ready;
+  data_t        p_data0;
+  data_t        p_data1;
+  logic         p_error;
+  logic  [ 4:0] p_rd;
+  logic         p_dual_writeback;
+  logic         p_valid;
+  logic         p_ready;
 
-  modport in (
-    input q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
-    output k_accept, k_writeback, q_ready,
-    output p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+  modport in(
+      input q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+      output k_accept, k_writeback, q_ready,
+      output p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
   );
 
-  modport out (
-    output q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
-    input k_accept, k_writeback, q_ready,
-    input p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+  modport out(
+      output q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+      input k_accept, k_writeback, q_ready,
+      input p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
   );
 
-  modport monitor (
-    output q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
-    input k_accept, k_writeback, q_ready,
-    input p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+  modport monitor(
+      output q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+      input k_accept, k_writeback, q_ready,
+      input p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
   );
 
   // pragma translate_off
-  `ifndef VERILATOR
-
+`ifndef VERILATOR
   // q channel
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> q_valid));
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_instr_data)));
@@ -254,8 +253,7 @@ interface ACC_X_BUS_DV #(
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_rd)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_error)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> p_valid));
-
-  `endif
+`endif
   // pragma translate_on
 endinterface
 
@@ -263,8 +261,8 @@ interface ACC_PRD_BUS;
 
 
   logic [31:0] q_instr_data;
-  logic [1:0]  p_writeback;
-  logic [2:0]  p_use_rs;
+  logic [ 1:0] p_writeback;
+  logic [ 2:0] p_use_rs;
   logic        p_accept;
 
   modport in (
@@ -280,12 +278,12 @@ interface ACC_PRD_BUS;
 endinterface
 
 interface ACC_PRD_BUS_DV (
-  input clk_i
+    input clk_i
 );
 
   logic [31:0] q_instr_data;
-  logic [1:0]  p_writeback;
-  logic [2:0]  p_use_rs;
+  logic [ 1:0] p_writeback;
+  logic [ 2:0] p_use_rs;
   logic        p_accept;
 
   modport in (
@@ -304,5 +302,4 @@ interface ACC_PRD_BUS_DV (
   );
 
   // No asserts. This interface is completely combinational
-
 endinterface

--- a/src/acc_intf.sv
+++ b/src/acc_intf.sv
@@ -20,41 +20,45 @@
 interface ACC_C_BUS #(
     // ISA bit width
     parameter int unsigned DataWidth = 32,
-    // Address Width
-    parameter int          AddrWidth = -1
+    // Address width
+    parameter int          AddrWidth = -1,
+    // Support for dual-writeback instructions
+    parameter bit          DualWriteback = 0,
+    // Support for ternary operations (use rs3)
+    parameter bit          TernaryOps = 0
 );
 
   typedef logic [DataWidth-1:0] data_t;
   typedef logic [AddrWidth-1:0] addr_t;
 
+  localparam int unsigned NumRs = TernaryOps ? 3 : 2;
+  localparam int unsigned NumWb = DualWriteback ? 2 : 1;
+
   // Request channel (Q).
-  addr_t        q_addr;
-  logic  [31:0] q_data_op;
-  data_t        q_data_arga;
-  data_t        q_data_argb;
-  data_t        q_data_argc;
-  logic  [31:0] q_hart_id;
-  logic         q_valid;
-  logic         q_ready;
+  addr_t             q_addr;
+  logic  [31:0]      q_instr_data;
+  data_t [NumRs-1:0] q_rs;
+  data_t             q_hart_id;
+  logic              q_valid;
+  logic              q_ready;
 
   // Response Channel (P).
-  data_t        p_data0;
-  data_t        p_data1;
-  logic         p_dual_writeback;
-  logic  [31:0] p_hart_id;
-  logic  [ 4:0] p_rd;
-  logic         p_error;
-  logic         p_valid;
-  logic         p_ready;
+  data_t [NumWb-1:0] p_data;
+  logic              p_dualwb;
+  data_t             p_hart_id;
+  logic  [ 4:0]      p_rd;
+  logic              p_error;
+  logic              p_valid;
+  logic              p_ready;
 
   modport in(
-      input q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_hart_id, q_valid, p_ready,
-      output q_ready, p_data0, p_data1, p_dual_writeback, p_hart_id, p_rd, p_error, p_valid
+      input q_addr, q_instr_data, q_rs, q_hart_id, q_valid, p_ready,
+      output q_ready, p_data, p_dualwb, p_hart_id, p_rd, p_error, p_valid
   );
 
   modport out(
-      output q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_hart_id, q_valid, p_ready,
-      input q_ready, p_data0, p_data1, p_dual_writeback, p_hart_id, p_rd, p_error, p_valid
+      output q_addr, q_instr_data, q_rs, q_hart_id, q_valid, p_ready,
+      input q_ready, p_data, p_dualwb, p_hart_id, p_rd, p_error, p_valid
   );
 
 endinterface
@@ -62,63 +66,64 @@ endinterface
 interface ACC_C_BUS_DV #(
     // ISA bit width
     parameter int unsigned DataWidth = 32,
-    // Address Width
-    parameter int          AddrWidth = -1
+    // Address width
+    parameter int          AddrWidth = -1,
+    // Support for dual-writeback instructions
+    parameter bit          DualWriteback = 0,
+    // Support for ternary operations (use rs3)
+    parameter bit          TernaryOps = 0
 ) (
-    input logic clk_i
+  input clk_i
 );
 
   typedef logic [DataWidth-1:0] data_t;
   typedef logic [AddrWidth-1:0] addr_t;
 
+  localparam int unsigned NumRs = TernaryOps ? 3 : 2;
+  localparam int unsigned NumWb = DualWriteback ? 2 : 1;
+
   // Request channel (Q).
-  addr_t        q_addr;
-  logic  [31:0] q_data_op;
-  data_t        q_data_arga;
-  data_t        q_data_argb;
-  data_t        q_data_argc;
-  logic  [31:0] q_hart_id;
-  logic         q_valid;
-  logic         q_ready;
+  addr_t             q_addr;
+  logic  [31:0]      q_instr_data;
+  data_t [NumRs-1:0] q_rs;
+  data_t             q_hart_id;
+  logic              q_valid;
+  logic              q_ready;
 
   // Response Channel (P).
-  data_t        p_data0;
-  data_t        p_data1;
-  logic         p_dual_writeback;
-  logic  [31:0] p_hart_id;
-  logic  [ 4:0] p_rd;
-  logic         p_error;
-  logic         p_valid;
-  logic         p_ready;
+  data_t [NumWb-1:0] p_data;
+  logic              p_dualwb;
+  data_t             p_hart_id;
+  logic  [ 4:0]      p_rd;
+  logic              p_error;
+  logic              p_valid;
+  logic              p_ready;
 
   modport in(
-      input q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_hart_id, q_valid, p_ready,
-      output q_ready, p_data0, p_data1, p_dual_writeback, p_hart_id, p_rd, p_error, p_valid
+      input q_addr, q_instr_data, q_rs, q_hart_id, q_valid, p_ready,
+      output q_ready, p_data, p_dualwb, p_hart_id, p_rd, p_error, p_valid
   );
 
   modport out(
-      output q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_hart_id, q_valid, p_ready,
-      input q_ready, p_data0, p_data1, p_dual_writeback, p_hart_id, p_rd, p_error, p_valid
+      output q_addr, q_instr_data, q_rs, q_hart_id, q_valid, p_ready,
+      input q_ready, p_data, p_dualwb, p_hart_id, p_rd, p_error, p_valid
   );
 
   modport monitor(
-      input q_addr, q_data_op, q_data_arga, q_data_argb, q_data_argc, q_hart_id, q_valid, p_ready,
-      input q_ready, p_data0, p_data1, p_dual_writeback, p_hart_id, p_rd, p_error, p_valid
+      input q_addr, q_instr_data, q_rs, q_hart_id, q_valid, p_ready,
+      input q_ready, p_data, p_dualwb, p_hart_id, p_rd, p_error, p_valid
   );
 
   // pragma translate_off
 `ifndef VERILATOR
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_addr)));
-  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data_op)));
-  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data_arga)));
-  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data_argb)));
-  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_data_argc)));
+  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_instr_data)));
+  assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_rs)));
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_hart_id)));
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> q_valid));
 
-  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_data0)));
-  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_data1)));
-  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_dual_writeback)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_data)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_dualwb)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_hart_id)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_rd)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_error)));
@@ -130,19 +135,23 @@ endinterface
 
 interface ACC_X_BUS #(
     // ISA bit Width
-    parameter int DataWidth = 32
+    parameter int unsigned DataWidth = 32,
+    // Support for dual-writeback instructions
+    parameter bit          DualWriteback = 0,
+    // Support for ternary operations (use rs3)
+    parameter bit          TernaryOps = 0
 );
 
   typedef logic [DataWidth-1:0] data_t;
+  localparam int unsigned NumRs = TernaryOps ? 3 : 2;
+  localparam int unsigned NumWb = DualWriteback ? 2 : 1;
 
   // Request Channel (Q)
-  logic  [31:0] q_instr_data;
-  data_t        q_rs1;
-  data_t        q_rs2;
-  data_t        q_rs3;
-  logic  [ 2:0] q_rs_valid;
-  logic  [ 1:0] q_rd_clean;
-  logic         q_valid;
+  logic  [     31:0] q_instr_data;
+  data_t [NumRs-1:0] q_rs;
+  logic  [NumRs-1:0] q_rs_valid;
+  logic  [NumWb-1:0] q_rd_clean;
+  logic              q_valid;
 
   // Acknowledge Channel (K)
   logic         k_accept;
@@ -150,47 +159,49 @@ interface ACC_X_BUS #(
   logic         q_ready;
 
   // Response Channel (P)
-  data_t        p_data0;
-  data_t        p_data1;
-  logic         p_dual_writeback;
-  logic  [ 4:0] p_rd;
-  logic         p_error;
-  logic         p_valid;
-  logic         p_ready;
+  data_t [NumWb-1:0] p_data;
+  logic              p_error;
+  logic  [ 4:0]      p_rd;
+  logic              p_dualwb;
+  logic              p_valid;
+  logic              p_ready;
 
   modport in(
-      input q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+      input q_instr_data, q_rs, q_rs_valid, q_rd_clean, q_valid, p_ready,
       output k_accept, k_writeback, q_ready,
-      output p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+      output p_data, p_dualwb, p_rd, p_error, p_valid
   );
 
   modport out(
-      output q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+      output q_instr_data, q_rs, q_rs_valid, q_rd_clean, q_valid, p_ready,
       input k_accept, k_writeback, q_ready,
-      input p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+      input p_data, p_dualwb, p_rd, p_error, p_valid
   );
-
 
 endinterface
 
 interface ACC_X_BUS_DV #(
     // ISA bit Width
-    parameter int DataWidth = 32
+    parameter int unsigned DataWidth = 32,
+    // Support for dual-writeback instructions
+    parameter bit          DualWriteback = 0,
+    // Support for ternary operations (use rs3)
+    parameter bit          TernaryOps = 0
 
 ) (
     input clk_i
 );
 
   typedef logic [DataWidth-1:0] data_t;
+  localparam int unsigned NumRs = TernaryOps ? 3 : 2;
+  localparam int unsigned NumWb = DualWriteback ? 2 : 1;
 
   // Request Channel (Q)
-  logic  [31:0] q_instr_data;
-  data_t        q_rs1;
-  data_t        q_rs2;
-  data_t        q_rs3;
-  logic  [ 2:0] q_rs_valid;
-  logic  [ 1:0] q_rd_clean;
-  logic         q_valid;
+  logic  [     31:0] q_instr_data;
+  data_t [NumRs-1:0] q_rs;
+  logic  [NumRs-1:0] q_rs_valid;
+  logic  [NumWb-1:0] q_rd_clean;
+  logic              q_valid;
 
   // Acknowledge Channel (K)
   logic         k_accept;
@@ -198,30 +209,29 @@ interface ACC_X_BUS_DV #(
   logic         q_ready;
 
   // Response Channel (P)
-  data_t        p_data0;
-  data_t        p_data1;
-  logic         p_error;
-  logic  [ 4:0] p_rd;
-  logic         p_dual_writeback;
-  logic         p_valid;
-  logic         p_ready;
+  data_t [NumWb-1:0] p_data;
+  logic              p_error;
+  logic  [ 4:0]      p_rd;
+  logic              p_dualwb;
+  logic              p_valid;
+  logic              p_ready;
 
   modport in(
-      input q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+      input q_instr_data, q_rs, q_rs_valid, q_rd_clean, q_valid, p_ready,
       output k_accept, k_writeback, q_ready,
-      output p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+      output p_data, p_dualwb, p_rd, p_error, p_valid
   );
 
   modport out(
-      output q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+      output q_instr_data, q_rs, q_rs_valid, q_rd_clean, q_valid, p_ready,
       input k_accept, k_writeback, q_ready,
-      input p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+      input p_data, p_dualwb, p_rd, p_error, p_valid
   );
 
   modport monitor(
-      output q_instr_data, q_rs1, q_rs2, q_rs3, q_rs_valid, q_rd_clean, q_valid, p_ready,
+      input q_instr_data, q_rs, q_rs_valid, q_rd_clean, q_valid, p_ready,
       input k_accept, k_writeback, q_ready,
-      input p_data0, p_data1, p_dual_writeback, p_rd, p_error, p_valid
+      input p_data, p_dualwb, p_rd, p_error, p_valid
   );
 
   // pragma translate_off
@@ -229,21 +239,16 @@ interface ACC_X_BUS_DV #(
   // q channel
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> q_valid));
   assert property (@(posedge clk_i) (q_valid && !q_ready |=> $stable(q_instr_data)));
-
-  assert property (@(posedge clk_i) (q_valid && q_rs_valid[0] && !q_ready |=> q_rs_valid[0]));
-  assert property (@(posedge clk_i) (q_valid && q_rs_valid[1] && !q_ready |=> q_rs_valid[1]));
-  assert property (@(posedge clk_i) (q_valid && q_rs_valid[2] && !q_ready |=> q_rs_valid[2]));
-  assert property (@(posedge clk_i) (q_valid && q_rs_valid[0] && !q_ready |=> $stable(q_rs1)));
-  assert property (@(posedge clk_i) (q_valid && q_rs_valid[1] && !q_ready |=> $stable(q_rs2)));
-  assert property (@(posedge clk_i) (q_valid && q_rs_valid[2] && !q_ready |=> $stable(q_rs3)));
-
+  for (genvar i = 0; i < NumRs; i++) begin : gen_rs_valid_assert
+    assert property (@(posedge clk_i) (q_valid && q_rs_valid[i] && !q_ready |=> q_rs_valid[i]));
+    assert property (@(posedge clk_i) (q_valid && q_rs_valid[i] && !q_ready |=> $stable(q_rs[i])));
+  end
   assert property (@(posedge clk_i)
       (q_valid && q_ready |-> ((k_writeback ~^ q_rd_clean) | ~k_writeback) == '1));
 
   // p channel
-  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_data0)));
-  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_data1)));
-  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_dual_writeback)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_data)));
+  assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_dualwb)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_rd)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> $stable(p_error)));
   assert property (@(posedge clk_i) (p_valid && !p_ready |=> p_valid));
@@ -286,12 +291,12 @@ interface ACC_PRD_BUS_DV (
 
   modport out (
     output q_instr_data,
-    input p_writeback, p_use_rs, p_accept
+    input  p_writeback, p_use_rs, p_accept
   );
 
   modport monitor (
     input  q_instr_data,
-    input p_writeback, p_use_rs, p_accept
+    input  p_writeback, p_use_rs, p_accept
   );
 
   // No asserts. This interface is completely combinational

--- a/src/acc_pkg.sv
+++ b/src/acc_pkg.sv
@@ -55,6 +55,6 @@ package acc_pkg;
     logic [31:0]  instr_data;
     logic [31:0]  instr_mask;
     acc_prd_rsp_t prd_rsp;
-  } acc_offl_instr_t;
+  } offload_instr_t;
 
 endpackage

--- a/src/acc_pkg.sv
+++ b/src/acc_pkg.sv
@@ -16,22 +16,22 @@ package acc_pkg;
   // TODO: put in cf_math_pkg or something? Is there a SV-function that does
   // this?
   //
-  function automatic int max (input int a, b);
-    return a>b ? a : b;
+  function automatic int max(int a, int b);
+    return a > b ? a : b;
   endfunction
 
   // Max value in array arr, up to element n-1
-  function automatic int maxn (input int arr[], n);
-    return n==0 ? 0 : n==1 ? arr[0] : max(arr[n-1], maxn(arr, n-1));
+  function automatic int maxn(int arr[], int n);
+    return n == 0 ? 0 : (n == 1 ? arr[0] : max(arr[n-1], maxn(arr, n - 1)));
   endfunction
 
-  function automatic int sum (input int a, b);
-    return a+b;
+  function automatic int sum(int a, int b);
+    return a + b;
   endfunction
 
   // Sum of array entries up to element n-1.
-  function automatic int sumn (input int arr[], n);
-    return n==0 ? 0 : n==1 ? arr[0] : sum(arr[n-1], sumn(arr, n-1));
+  function automatic int sumn(int arr[], int n);
+    return n == 0 ? 0 : (n == 1 ? arr[0] : sum(arr[n-1], sumn(arr, n - 1)));
   endfunction
 
   /////////////////////////
@@ -40,9 +40,9 @@ package acc_pkg;
 
   // Response type
   typedef struct packed {
-    logic          p_accept;
-    logic [1:0]    p_writeback;
-    logic [2:0]    p_use_rs;
+    logic       p_accept;
+    logic [1:0] p_writeback;
+    logic [2:0] p_use_rs;
   } acc_prd_rsp_t;
 
   // Request type
@@ -50,13 +50,11 @@ package acc_pkg;
     logic [31:0] q_instr_data;
   } acc_prd_req_t;
 
-
   // Internal instruction metadata
   typedef struct packed {
-    logic [31:0]   instr_data;
-    logic [31:0]   instr_mask;
-    acc_prd_rsp_t      prd_rsp;
+    logic [31:0]  instr_data;
+    logic [31:0]  instr_mask;
+    acc_prd_rsp_t prd_rsp;
   } acc_offl_instr_t;
-
 
 endpackage

--- a/src/acc_pkg.sv
+++ b/src/acc_pkg.sv
@@ -1,0 +1,62 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Noam Gallmann <gnoam@live.com>
+
+package acc_pkg;
+  // TODO: define common cluster parameters in package (Total number of
+  // responders / requesters per level)
+
+
+  // Helper Functions for *constant* localparam definitions.
+  // array functions (e.g.  'arr.sum()') return queue type which is not
+  // considered constant for use as synthesis-time parameter.
+
+  // TODO: put in cf_math_pkg or something? Is there a SV-function that does
+  // this?
+  //
+  function automatic int max (input int a, b);
+    return a>b ? a : b;
+  endfunction
+
+  // Max value in array arr, up to element n-1
+  function automatic int maxn (input int arr[], n);
+    return n==0 ? 0 : n==1 ? arr[0] : max(arr[n-1], maxn(arr, n-1));
+  endfunction
+
+  function automatic int sum (input int a, b);
+    return a+b;
+  endfunction
+
+  // Sum of array entries up to element n-1.
+  function automatic int sumn (input int arr[], n);
+    return n==0 ? 0 : n==1 ? arr[0] : sum(arr[n-1], sumn(arr, n-1));
+  endfunction
+
+  /////////////////////////
+  // Predecoder Typedefs //
+  /////////////////////////
+
+  // Response type
+  typedef struct packed {
+    logic          p_accept;
+    logic [1:0]    p_writeback;
+    logic [2:0]    p_use_rs;
+  } acc_prd_rsp_t;
+
+  // Request type
+  typedef struct packed {
+    logic [31:0] q_instr_data;
+  } acc_prd_req_t;
+
+
+  // Internal instruction metadata
+  typedef struct packed {
+    logic [31:0]   instr_data;
+    logic [31:0]   instr_mask;
+    acc_prd_rsp_t      prd_rsp;
+  } acc_offl_instr_t;
+
+
+endpackage

--- a/src/acc_predecoder.sv
+++ b/src/acc_predecoder.sv
@@ -1,0 +1,73 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Noam Gallmann <gnoam@live.com>
+
+// Per-extension instruction metadata predecoder
+
+module acc_predecoder #(
+  parameter int     NumInstr                              = -1,
+  parameter acc_pkg::acc_offl_instr_t OfflInstr[NumInstr] = {-1}
+) (
+
+  input  acc_pkg::acc_prd_req_t prd_req_i,
+  output acc_pkg::acc_prd_rsp_t prd_rsp_o
+);
+
+  import acc_pkg::*;
+
+  acc_prd_rsp_t [NumInstr-1:0] instr_rsp;
+  logic [NumInstr-1:0]         instr_sel;
+
+  for (genvar i=0; i<NumInstr; i++) begin : gen_predecoder_selector
+    assign instr_sel[i] =
+      ((OfflInstr[i].instr_mask & prd_req_i.q_instr_data) == OfflInstr[i].instr_data);
+  end
+
+  for ( genvar i=0; i<NumInstr; i++) begin : gen_predecoder_mux
+      assign instr_rsp[i].p_accept    = instr_sel[i] ? 1'b1 : 1'b0;
+      assign instr_rsp[i].p_writeback = instr_sel[i] ? OfflInstr[i].prd_rsp.p_writeback : '0;
+      assign instr_rsp[i].p_use_rs    = instr_sel[i] ? OfflInstr[i].prd_rsp.p_use_rs : '0;
+  end
+
+  always_comb begin
+    prd_rsp_o.p_accept    = 1'b0;
+    prd_rsp_o.p_writeback = '0;
+    prd_rsp_o.p_use_rs    = '0;
+    for (int unsigned i=0; i<NumInstr; i++) begin
+      prd_rsp_o.p_accept    |= instr_rsp[i].p_accept;
+      prd_rsp_o.p_writeback |= instr_rsp[i].p_writeback;
+      prd_rsp_o.p_use_rs    |= instr_rsp[i].p_use_rs;
+    end
+  end
+
+endmodule
+
+
+`include "acc_interface/assign.svh"
+
+module acc_predecoder_intf #(
+  parameter int NumInstr = -1,
+  parameter acc_pkg::acc_offl_instr_t OfflInstr[NumInstr] = {-1}
+) (
+  ACC_PRD_BUS prd
+);
+
+  acc_pkg::acc_prd_req_t prd_req;
+  acc_pkg::acc_prd_rsp_t prd_rsp;
+
+  `ACC_PRD_ASSIGN_TO_RESP(prd_rsp, prd)
+  `ACC_PRD_ASSIGN_FROM_REQ(prd, prd_req)
+
+
+  acc_predecoder #(
+    .NumInstr  ( NumInstr  ),
+    .OfflInstr ( OfflInstr )
+  ) acc_predecoder_i (
+    .prd_req_i ( prd_req ),
+    .prd_rsp_o ( prd_rsp )
+  );
+
+endmodule
+

--- a/src/acc_predecoder.sv
+++ b/src/acc_predecoder.sv
@@ -7,8 +7,8 @@
 // Per-extension instruction metadata predecoder
 
 module acc_predecoder #(
-    parameter int                       NumInstr            = -1,
-    parameter acc_pkg::acc_offl_instr_t OfflInstr[NumInstr] = {-1}
+    parameter int                       NumInstr               = -1,
+    parameter acc_pkg::offload_instr_t  OffloadInstr[NumInstr] = {-1}
 ) (
     input  acc_pkg::acc_prd_req_t prd_req_i,
     output acc_pkg::acc_prd_rsp_t prd_rsp_o
@@ -21,13 +21,13 @@ module acc_predecoder #(
 
   for (genvar i = 0; i < NumInstr; i++) begin : gen_predecoder_selector
     assign instr_sel[i] =
-      ((OfflInstr[i].instr_mask & prd_req_i.q_instr_data) == OfflInstr[i].instr_data);
+      ((OffloadInstr[i].instr_mask & prd_req_i.q_instr_data) == OffloadInstr[i].instr_data);
   end
 
   for (genvar i = 0; i < NumInstr; i++) begin : gen_predecoder_mux
     assign instr_rsp[i].p_accept    = instr_sel[i] ? 1'b1 : 1'b0;
-    assign instr_rsp[i].p_writeback = instr_sel[i] ? OfflInstr[i].prd_rsp.p_writeback : '0;
-    assign instr_rsp[i].p_use_rs    = instr_sel[i] ? OfflInstr[i].prd_rsp.p_use_rs : '0;
+    assign instr_rsp[i].p_writeback = instr_sel[i] ? OffloadInstr[i].prd_rsp.p_writeback : '0;
+    assign instr_rsp[i].p_use_rs    = instr_sel[i] ? OffloadInstr[i].prd_rsp.p_use_rs : '0;
   end
 
   always_comb begin
@@ -47,7 +47,7 @@ endmodule
 
 module acc_predecoder_intf #(
     parameter int NumInstr = -1,
-    parameter acc_pkg::acc_offl_instr_t OfflInstr[NumInstr] = {-1}
+    parameter acc_pkg::offload_instr_t OffloadInstr[NumInstr] = {-1}
 ) (
     ACC_PRD_BUS prd
 );
@@ -59,8 +59,8 @@ module acc_predecoder_intf #(
   `ACC_PRD_ASSIGN_FROM_REQ(prd, prd_req)
 
   acc_predecoder #(
-      .NumInstr  ( NumInstr  ),
-      .OfflInstr ( OfflInstr )
+      .NumInstr     ( NumInstr     ),
+      .OffloadInstr ( OffloadInstr )
   ) acc_predecoder_i (
       .prd_req_i ( prd_req ),
       .prd_rsp_o ( prd_rsp )

--- a/src/acc_predecoder.sv
+++ b/src/acc_predecoder.sv
@@ -7,35 +7,34 @@
 // Per-extension instruction metadata predecoder
 
 module acc_predecoder #(
-  parameter int     NumInstr                              = -1,
-  parameter acc_pkg::acc_offl_instr_t OfflInstr[NumInstr] = {-1}
+    parameter int                       NumInstr            = -1,
+    parameter acc_pkg::acc_offl_instr_t OfflInstr[NumInstr] = {-1}
 ) (
-
-  input  acc_pkg::acc_prd_req_t prd_req_i,
-  output acc_pkg::acc_prd_rsp_t prd_rsp_o
+    input  acc_pkg::acc_prd_req_t prd_req_i,
+    output acc_pkg::acc_prd_rsp_t prd_rsp_o
 );
 
   import acc_pkg::*;
 
   acc_prd_rsp_t [NumInstr-1:0] instr_rsp;
-  logic [NumInstr-1:0]         instr_sel;
+  logic         [NumInstr-1:0] instr_sel;
 
-  for (genvar i=0; i<NumInstr; i++) begin : gen_predecoder_selector
+  for (genvar i = 0; i < NumInstr; i++) begin : gen_predecoder_selector
     assign instr_sel[i] =
       ((OfflInstr[i].instr_mask & prd_req_i.q_instr_data) == OfflInstr[i].instr_data);
   end
 
-  for ( genvar i=0; i<NumInstr; i++) begin : gen_predecoder_mux
-      assign instr_rsp[i].p_accept    = instr_sel[i] ? 1'b1 : 1'b0;
-      assign instr_rsp[i].p_writeback = instr_sel[i] ? OfflInstr[i].prd_rsp.p_writeback : '0;
-      assign instr_rsp[i].p_use_rs    = instr_sel[i] ? OfflInstr[i].prd_rsp.p_use_rs : '0;
+  for (genvar i = 0; i < NumInstr; i++) begin : gen_predecoder_mux
+    assign instr_rsp[i].p_accept    = instr_sel[i] ? 1'b1 : 1'b0;
+    assign instr_rsp[i].p_writeback = instr_sel[i] ? OfflInstr[i].prd_rsp.p_writeback : '0;
+    assign instr_rsp[i].p_use_rs    = instr_sel[i] ? OfflInstr[i].prd_rsp.p_use_rs : '0;
   end
 
   always_comb begin
     prd_rsp_o.p_accept    = 1'b0;
     prd_rsp_o.p_writeback = '0;
     prd_rsp_o.p_use_rs    = '0;
-    for (int unsigned i=0; i<NumInstr; i++) begin
+    for (int unsigned i = 0; i < NumInstr; i++) begin
       prd_rsp_o.p_accept    |= instr_rsp[i].p_accept;
       prd_rsp_o.p_writeback |= instr_rsp[i].p_writeback;
       prd_rsp_o.p_use_rs    |= instr_rsp[i].p_use_rs;
@@ -44,14 +43,13 @@ module acc_predecoder #(
 
 endmodule
 
-
 `include "acc_interface/assign.svh"
 
 module acc_predecoder_intf #(
-  parameter int NumInstr = -1,
-  parameter acc_pkg::acc_offl_instr_t OfflInstr[NumInstr] = {-1}
+    parameter int NumInstr = -1,
+    parameter acc_pkg::acc_offl_instr_t OfflInstr[NumInstr] = {-1}
 ) (
-  ACC_PRD_BUS prd
+    ACC_PRD_BUS prd
 );
 
   acc_pkg::acc_prd_req_t prd_req;
@@ -60,14 +58,12 @@ module acc_predecoder_intf #(
   `ACC_PRD_ASSIGN_TO_RESP(prd_rsp, prd)
   `ACC_PRD_ASSIGN_FROM_REQ(prd, prd_req)
 
-
   acc_predecoder #(
-    .NumInstr  ( NumInstr  ),
-    .OfflInstr ( OfflInstr )
+      .NumInstr  ( NumInstr  ),
+      .OfflInstr ( OfflInstr )
   ) acc_predecoder_i (
-    .prd_req_i ( prd_req ),
-    .prd_rsp_o ( prd_rsp )
+      .prd_req_i ( prd_req ),
+      .prd_rsp_o ( prd_rsp )
   );
 
 endmodule
-

--- a/src/acc_test.sv
+++ b/src/acc_test.sv
@@ -1,0 +1,1330 @@
+// Copyright 2020 ETH Zurich and University of Bologna.::
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Noam Gallmann <gnoam@live.com>
+
+package acc_test;
+
+  import acc_pkg::*;
+
+  //////////////////////////////////////////////
+  // Accelerator Interconnect Test Structures //
+  //////////////////////////////////////////////
+
+  class c_req_t #(
+    parameter int AddrWidth = -1,
+    parameter int DataWidth = -1,
+    parameter int IdWidth   = -1
+  );
+    rand logic [AddrWidth-1:0] addr;
+    rand logic [DataWidth-1:0] data_arga;
+    rand logic [DataWidth-1:0] data_argb;
+    rand logic [DataWidth-1:0] data_argc;
+    rand logic [31:0]          data_op;
+    rand logic [IdWidth-1:0]   id;
+
+    constraint id_lsb_c {
+      id[0] == 1'b0;
+    };
+
+    typedef c_req_t # (
+      .AddrWidth ( AddrWidth ),
+      .DataWidth ( DataWidth ),
+      .IdWidth   ( IdWidth   )
+    ) int_c_req_t;
+
+    function do_compare (int_c_req_t req);
+      return addr      == req.addr      &&
+             data_arga == req.data_arga &&
+             data_argb == req.data_argb &&
+             data_argc == req.data_argc &&
+             data_op   == req.data_op;
+    endfunction
+
+    task display;
+      $display(
+              "c_req.addr: %x\n",       addr,
+              "c_req.data_op: %x\n",    data_op,
+              "c_req.data_arga: %x\n",  data_arga,
+              "c_req.data_argb: %x\n",  data_argb,
+              "c_req.data_argc: %x\n",  data_argc,
+              "c_req.id: %x\n",         id,
+              "\n"
+            );
+    endtask
+  endclass
+
+  // Compare C requests of different parameterizations.
+  // different parametrizations
+  class compare_c_req #(
+    parameter type mst_c_req_t = logic,
+    parameter type slv_c_req_t = logic
+  );
+    static function do_compare(mst_c_req_t mst_req, slv_c_req_t slv_req);
+      return mst_req.addr      == slv_req.addr      &&
+             mst_req.data_arga == slv_req.data_arga &&
+             mst_req.data_argb == slv_req.data_argb &&
+             mst_req.data_argc == slv_req.data_argc &&
+             mst_req.data_op   == slv_req.data_op;
+    endfunction
+  endclass
+
+
+  class c_rsp_t #(
+    parameter int DataWidth = -1,
+    parameter int IdWidth   = -1
+  );
+    rand logic [DataWidth-1:0] data0;
+    rand logic [DataWidth-1:0] data1;
+    rand logic                 dual_writeback;
+    rand logic                 error;
+    logic [4:0]                rd; // not random!
+    logic [IdWidth-1:0]        id;
+
+    typedef c_rsp_t # (
+      .DataWidth    ( DataWidth ),
+      .IdWidth      ( IdWidth   )
+    ) int_c_rsp_t;
+
+    task display;
+      $display(
+              "c_rsp.data0: %x\n",          data0,
+              "c_rsp.data1: %x\n",          data1,
+              "c_rsp.dual_writeback: %x\n", dual_writeback,
+              "c_rsp.error %x\n",           error,
+              "c_rsp.rd: %x\n",             rd,
+              "c_rsp.id: %x\n",             id,
+              "\n"
+            );
+    endtask
+
+    function do_compare (int_c_rsp_t rsp);
+      return data0          == rsp.data0          &
+             data1          == rsp.data1          &
+             dual_writeback == rsp.dual_writeback &
+             error          == rsp.error          &
+             rd             == rsp.rd;
+    endfunction
+  endclass
+
+
+  // Compare rsps of different parameterizations.
+  class compare_c_rsp #(
+    parameter type mst_c_rsp_t = logic,
+    parameter type slv_c_rsp_t = logic
+  );
+    static function do_compare(mst_c_rsp_t mst_rsp, slv_c_rsp_t slv_rsp);
+      return mst_rsp.data0          == slv_rsp.data0          &
+             mst_rsp.data1          == slv_rsp.data1          &
+             mst_rsp.dual_writeback == slv_rsp.dual_writeback &
+             mst_rsp.error          == slv_rsp.error          &
+             mst_rsp.rd             == slv_rsp.rd;
+    endfunction
+  endclass
+
+  class acc_c_driver #(
+    parameter int AddrWidth = -1,
+    parameter int DataWidth = -1,
+    parameter int IdWidth   = -1,
+    parameter time TA       = 0, // stimuli application time
+    parameter time TT       = 0  // stimuli test time
+  );
+
+    typedef c_req_t #(
+      .DataWidth ( DataWidth ),
+      .AddrWidth ( AddrWidth ),
+      .IdWidth   ( IdWidth   )
+    ) int_c_req_t;
+
+    typedef c_rsp_t #(
+      .DataWidth ( DataWidth ),
+      .IdWidth   ( IdWidth   )
+    ) int_c_rsp_t;
+
+    virtual ACC_C_BUS_DV # (
+      .DataWidth ( DataWidth ),
+      .AddrWidth ( AddrWidth ),
+      .IdWidth   ( IdWidth   )
+    ) bus;
+
+    function new(
+      virtual ACC_C_BUS_DV #(
+        .DataWidth ( DataWidth ),
+        .AddrWidth ( AddrWidth ),
+        .IdWidth   ( IdWidth   )
+      ) bus
+    );
+      this.bus=bus;
+    endfunction
+
+    task reset_master;
+      bus.q_addr      <= '0;
+      bus.q_data_op   <= '0;
+      bus.q_data_arga <= '0;
+      bus.q_data_argb <= '0;
+      bus.q_data_argc <= '0;
+      bus.q_id        <= '0;
+      bus.q_valid     <= '0;
+      bus.p_ready     <= '0;
+    endtask
+
+    task reset_slave;
+      bus.p_data0          <= '0;
+      bus.p_data1          <= '0;
+      bus.p_dual_writeback <= '0;
+      bus.p_id             <= '0;
+      bus.p_rd             <= '0;
+      bus.p_error          <= '0;
+      bus.p_valid          <= '0;
+      bus.q_ready          <= '0;
+    endtask
+
+    task cycle_start;
+      #TT;
+    endtask
+
+    task cycle_end;
+      @(posedge bus.clk_i);
+    endtask
+
+    // Send a request.
+    task send_req (input int_c_req_t req);
+      bus.q_addr      <= #TA req.addr;
+      bus.q_data_op   <= #TA req.data_op;
+      bus.q_data_arga <= #TA req.data_arga;
+      bus.q_data_argb <= #TA req.data_argb;
+      bus.q_data_argc <= #TA req.data_argc;
+      bus.q_id        <= #TA req.id;
+      bus.q_valid     <= #TA 1;
+      cycle_start();
+      while (bus.q_ready != 1) begin cycle_end(); cycle_start(); end
+      cycle_end();
+      bus.q_addr      <= #TA '0;
+      bus.q_data_op   <= #TA '0;
+      bus.q_data_arga <= #TA '0;
+      bus.q_data_argb <= #TA '0;
+      bus.q_data_argc <= #TA '0;
+      bus.q_id        <= #TA '0;
+      bus.q_valid     <= #TA  0;
+    endtask
+
+    // Send a response.
+    task send_rsp(input int_c_rsp_t rsp);
+      bus.p_data0          <= #TA rsp.data0;
+      bus.p_data1          <= #TA rsp.data1;
+      bus.p_dual_writeback <= #TA rsp.dual_writeback;
+      bus.p_id             <= #TA rsp.id;
+      bus.p_rd             <= #TA rsp.rd;
+      bus.p_error          <= #TA rsp.error;
+      bus.p_valid          <= #TA 1;
+      cycle_start();
+      while (bus.p_ready != 1) begin cycle_end(); cycle_start(); end
+      cycle_end();
+      bus.p_data0          <= #TA '0;
+      bus.p_data1          <= #TA '0;
+      bus.p_dual_writeback <= #TA '0;
+      bus.p_id             <= #TA '0;
+      bus.p_rd             <= #TA '0;
+      bus.p_error          <= #TA '0;
+      bus.p_valid          <= #TA 0;
+    endtask
+
+    // Receive a request.
+    task recv_req (output int_c_req_t req );
+      bus.q_ready <= #TA 1;
+      cycle_start();
+      while (bus.q_valid != 1) begin cycle_end(); cycle_start(); end
+      req = new;
+      req.addr      = bus.q_addr;
+      req.data_op   = bus.q_data_op;
+      req.data_arga = bus.q_data_arga;
+      req.data_argb = bus.q_data_argb;
+      req.data_argc = bus.q_data_argc;
+      req.id        = bus.q_id;
+      cycle_end();
+      bus.q_ready <= #TA 0;
+    endtask
+
+    // Receive a response.
+    task recv_rsp (output int_c_rsp_t rsp);
+      bus.p_ready <= #TA 1;
+      cycle_start();
+      while (bus.p_valid != 1) begin cycle_end(); cycle_start(); end
+      rsp                = new;
+      rsp.data0          = bus.p_data0;
+      rsp.data1          = bus.p_data1;
+      rsp.dual_writeback = bus.p_dual_writeback;
+      rsp.error          = bus.p_error;
+      rsp.id             = bus.p_id;
+      rsp.rd             = bus.p_rd;
+      cycle_end();
+      bus.p_ready <= #TA 0;
+    endtask
+
+    // Monitor request
+    task mon_req (output int_c_req_t req);
+      cycle_start();
+      while (!(bus.q_valid && bus.q_ready)) begin cycle_end(); cycle_start(); end
+      req = new;
+      req.addr      = bus.q_addr;
+      req.data_op   = bus.q_data_op;
+      req.data_arga = bus.q_data_arga;
+      req.data_argb = bus.q_data_argb;
+      req.data_argc = bus.q_data_argc;
+      req.id        = bus.q_id;
+      cycle_end();
+    endtask
+
+    // Monitor response.
+    task mon_rsp (output int_c_rsp_t rsp);
+      cycle_start();
+      while (!(bus.p_valid &&bus.p_ready)) begin cycle_end(); cycle_start(); end
+      rsp                = new;
+      rsp.data0          = bus.p_data0;
+      rsp.data1          = bus.p_data1;
+      rsp.dual_writeback = bus.p_dual_writeback;
+      rsp.error          = bus.p_error;
+      rsp.id             = bus.p_id;
+      rsp.rd             = bus.p_rd;
+      cycle_end();
+    endtask
+
+  endclass
+
+  // Super classes for random acc drivers
+  virtual class rand_c #(
+    // Acc interface parameters
+    parameter int DataWidth    = -1,
+    parameter int AddrWidth    = -1,
+    parameter int IdWidth      = -1,
+
+    // Stimuli application and test time
+    parameter time TA = 0ps,
+    parameter time TT = 0ps
+  );
+
+    typedef c_req_t #(
+      .AddrWidth    ( AddrWidth    ),
+      .DataWidth    ( DataWidth    ),
+      .IdWidth      ( IdWidth      )
+    ) int_c_req_t;
+
+    typedef c_rsp_t #(
+      .DataWidth    ( DataWidth  ),
+      .IdWidth      ( IdWidth    )
+    ) int_c_rsp_t;
+
+    typedef acc_test::acc_c_driver #(
+      // Acc interface parameters
+      .AddrWidth    ( AddrWidth    ),
+      .DataWidth    ( DataWidth    ),
+      .IdWidth      ( IdWidth      ),
+      // Stimuli application and test time
+      .TA(TA),
+      .TT(TT)
+    ) acc_c_driver_t;
+
+    acc_c_driver_t drv;
+
+    function new(
+      virtual ACC_C_BUS_DV #(
+        .DataWidth    ( DataWidth    ),
+        .AddrWidth    ( AddrWidth    ),
+        .IdWidth      ( IdWidth      )
+      ) bus );
+      this.drv = new (bus);
+    endfunction
+
+    task automatic rand_wait(input int unsigned min, input int unsigned max);
+      int unsigned rand_success, cycles;
+      rand_success = std::randomize(cycles) with {
+        cycles >= min;
+        cycles <= max;
+        // Weigh the distribution so that the minimum cycle time is the common
+        // case.
+        cycles dist {min := 10, [min+1:max] := 1};
+      };
+      assert (rand_success) else $error("Failed to randomize wait cycles!");
+      repeat (cycles) @(posedge this.drv.bus.clk_i);
+    endtask
+
+  endclass
+
+  // Generate random requests as a master device.
+  class rand_c_master #(
+    // Acc interface parameters
+    parameter int DataWidth       = -1,
+    parameter int AccAddrWidth    = -1,
+    parameter int AddrWidth       = -1,
+    parameter int IdWidth         = -1,
+    parameter int NumHier         = -1,
+    parameter int HierLevel       = -1,
+    parameter int NumRsp[NumHier] = '{-1},
+    // Stimuli application and test time
+    parameter time         TA                  = 0ps,
+    parameter time         TT                  = 0ps,
+    parameter int unsigned REQ_MIN_WAIT_CYCLES = 1,
+    parameter int unsigned REQ_MAX_WAIT_CYCLES = 20,
+    parameter int unsigned RSP_MIN_WAIT_CYCLES = 1,
+    parameter int unsigned RSP_MAX_WAIT_CYCLES = 20
+  ) extends rand_c #(
+      // Acc interface parameters
+      .DataWidth ( DataWidth ),
+      .AddrWidth ( AddrWidth ),
+      .IdWidth   ( IdWidth   ),
+      // Stimuli application and test time
+      .TA ( TA ),
+      .TT ( TT )
+    );
+
+    int unsigned cnt = 0;
+    bit req_done     = 0;
+
+    // Reset the driver.
+    task reset();
+      drv.reset_master();
+    endtask
+
+    // Constructor.
+    function new (
+      virtual ACC_C_BUS_DV #(
+        .DataWidth ( DataWidth ),
+        .AddrWidth ( AddrWidth ),
+        .IdWidth   ( IdWidth   )
+      ) bus );
+      super.new(bus);
+    endfunction
+
+    task run(input int n);
+      fork
+        send_requests(n);
+        recv_response();
+      join
+    endtask
+
+    // Send random requests.
+    task send_requests (input int n);
+      automatic int_c_req_t req = new;
+
+      repeat (n) begin
+        this.cnt++;
+        assert(req.randomize with
+          {
+            addr[AddrWidth-1:AccAddrWidth] inside {[HierLevel:NumHier-1]};
+            addr[AccAddrWidth-1:0]         inside {[0:NumRsp[addr[AddrWidth-1:AccAddrWidth]]-1]};
+          }
+        );
+        rand_wait(REQ_MIN_WAIT_CYCLES, REQ_MAX_WAIT_CYCLES);
+        this.drv.send_req(req);
+      end
+      this.req_done = 1;
+    endtask
+
+    // Receive random responses.
+    task recv_response;
+      while (!this.req_done || this.cnt > 0) begin
+        automatic int_c_rsp_t rsp;
+        this.cnt--;
+        rand_wait(RSP_MIN_WAIT_CYCLES, RSP_MAX_WAIT_CYCLES);
+        this.drv.recv_rsp(rsp);
+      end
+    endtask
+  endclass
+
+  class rand_c_slave #(
+    // Acc interface parameters
+    parameter int AddrWidth    = -1,
+    parameter int DataWidth    = -1,
+    parameter int IdWidth      = -1,
+    // Stimuli application and test time
+    parameter time  TA = 0ps,
+    parameter time  TT = 0ps,
+    parameter int unsigned REQ_MIN_WAIT_CYCLES = 0,
+    parameter int unsigned REQ_MAX_WAIT_CYCLES = 10,
+    parameter int unsigned RSP_MIN_WAIT_CYCLES = 0,
+    parameter int unsigned RSP_MAX_WAIT_CYCLES = 10
+  ) extends rand_c #(
+      // Acc interface parameters
+      .AddrWidth ( AddrWidth ),
+      .DataWidth ( DataWidth ),
+      .IdWidth   ( IdWidth   ),
+      // Stimuli application and test time
+      .TA(TA),
+      .TT(TT)
+    );
+
+    mailbox req_mbx[2**IdWidth];
+
+    /// Reset the driver.
+    task reset();
+      drv.reset_slave();
+    endtask
+
+    task run();
+      fork
+        recv_requests();
+        send_responses();
+      join
+    endtask
+
+    /// Constructor.
+    function new (
+      virtual ACC_C_BUS_DV #(
+        .DataWidth    ( DataWidth    ),
+        .AddrWidth    ( AddrWidth    ),
+        .IdWidth      ( IdWidth      )
+      ) bus);
+      super.new(bus);
+      foreach(this.req_mbx[ii]) req_mbx[ii] = new();
+    endfunction
+
+    task recv_requests();
+      forever begin
+        automatic int_c_req_t req;
+        rand_wait(REQ_MIN_WAIT_CYCLES, REQ_MAX_WAIT_CYCLES);
+        this.drv.recv_req(req);
+        req_mbx[req.id >> 1].put(req);
+      end
+    endtask
+
+    task send_responses();
+      forever begin
+        automatic int_c_rsp_t rsp = new;
+        automatic int_c_req_t req;
+        // generate random sequence of requesters.
+        automatic int req_id[2**IdWidth];
+        automatic bit req_found = 1'b0;
+        // randomly pick a request
+        for (int i =0; i<2**IdWidth; i++) begin
+          req_id[i] = i;
+        end
+        req_id.shuffle();
+        for (int i=0; i<2**IdWidth; i++) begin
+          automatic int r_id = req_id[i];
+          if (req_mbx[r_id].num() != 0) begin
+            req_mbx[r_id].get(req);
+            req_found = 1'b1;
+            break;
+          end
+        end
+        if (req_found==1'b1) begin
+          // generate and send random response.
+          assert(rsp.randomize());
+          // get Id + Rd from corresponding request.
+          rsp.id = req.id;
+          rsp.rd = req.data_op[11:7];
+          // send response back to requester.
+          @(posedge this.drv.bus.clk_i);
+          rand_wait(RSP_MIN_WAIT_CYCLES, RSP_MAX_WAIT_CYCLES);
+          this.drv.send_rsp(rsp);
+        end else begin
+          this.drv.cycle_end();
+        end
+      end
+    endtask
+  endclass
+
+  class acc_c_slv_monitor #(
+    // Acc interface parameters
+    parameter int DataWidth    = -1,
+    parameter int AddrWidth    = -1,
+    parameter int IdWidth      = -1,
+    // Stimuli application and test time
+    parameter time  TA = 0ps,
+    parameter time  TT = 0ps
+  ) extends rand_c #(
+        .DataWidth    ( DataWidth    ),
+        .AddrWidth    ( AddrWidth    ),
+        .IdWidth      ( IdWidth      ),
+        .TA           ( TA           ),
+        .TT           ( TT           )
+  );
+
+    mailbox req_mbx[IdWidth**2];
+    mailbox rsp_mbx[IdWidth**2];
+
+    // Constructor.
+    function new (
+      virtual ACC_C_BUS_DV #(
+        .DataWidth    ( DataWidth    ),
+        .AddrWidth    ( AddrWidth    ),
+        .IdWidth      ( IdWidth      )
+      ) bus);
+      super.new(bus);
+      foreach (this.req_mbx[ii]) req_mbx[ii] = new();
+      foreach (this.rsp_mbx[ii]) rsp_mbx[ii] = new();
+
+    endfunction
+
+    // Slave Monitor.
+    // For each master maintain a separate mailbox.
+    task monitor;
+      fork
+        forever begin
+          automatic int_c_req_t req;
+          this.drv.mon_req(req);
+          // put in req mbox corresponding to the requester
+          req_mbx[req.id].put(req);
+        end
+        forever begin
+          automatic int_c_rsp_t rsp;
+          this.drv.mon_rsp(rsp);
+          // put in req mbox corresponding to the requester
+          rsp_mbx[rsp.id].put(rsp);
+        end
+      join
+    endtask
+  endclass
+
+  class acc_c_mst_monitor #(
+    // Acc interface parameters
+    parameter int DataWidth    = -1,
+    parameter int AddrWidth    = -1,
+    parameter int AccAddrWidth = -1,
+    parameter int IdWidth      = -1,
+    parameter int HierLevel    = -1,
+    // Stimuli application and test time
+    parameter time  TA = 0ps,
+    parameter time  TT = 0ps
+  ) extends rand_c #(
+        .DataWidth ( DataWidth ),
+        .AddrWidth ( AddrWidth ),
+        .IdWidth   ( IdWidth   ),
+        .TA        ( TA        ),
+        .TT        ( TT        )
+    );
+
+    mailbox req_mbx [AccAddrWidth**2];
+    mailbox req_mbx_fwd = new;
+    mailbox rsp_mbx = new;
+
+    // Constructor.
+    function new (
+      virtual ACC_C_BUS_DV #(
+        .DataWidth ( DataWidth ),
+        .AddrWidth ( AddrWidth ),
+        .IdWidth   ( IdWidth   )
+      ) bus);
+      super.new(bus);
+      foreach (this.req_mbx[ii]) req_mbx[ii] = new;
+    endfunction
+
+    // Master Monitor.
+    // For each slave maintain a separate mailbox.
+    task monitor;
+      fork
+        forever begin
+          automatic int_c_req_t req;
+          this.drv.mon_req(req);
+          //req.display();
+          // Check if request addresses this level
+          if (req.addr[AddrWidth-1:AccAddrWidth] == HierLevel) begin
+            // put in req mbox corresponding to the responder
+            req_mbx[req.addr[AccAddrWidth-1:0]].put(req);
+          end else begin
+            // put in fwd req mbx
+            req_mbx_fwd.put(req);
+          end
+        end
+        forever begin
+          automatic int_c_rsp_t rsp;
+          this.drv.mon_rsp(rsp);
+          rsp_mbx.put(rsp);
+        end
+      join
+    endtask
+  endclass
+
+  /////////////////////////////////////////
+  // Accelerator Adapter Test Structures //
+  /////////////////////////////////////////
+
+  class x_req_t #(
+    parameter int DataWidth = -1
+  );
+    // REQ Channel
+    randc logic [31:0]         instr_data;
+    rand logic [DataWidth-1:0] rs1;
+    rand logic [DataWidth-1:0] rs2;
+    rand logic [DataWidth-1:0] rs3;
+    rand logic [2:0]           rs_valid;
+    rand logic [2:0]           rd_clean;
+    // ACK channel
+    rand logic       accept;
+    rand logic [1:0] writeback;
+
+    // Helper for randomization
+    logic [2:0] last_rs_valid;
+    logic [2:0] last_rd_clean;
+    function void post_randomize;
+      last_rs_valid = rs_valid;
+      last_rd_clean = rd_clean;
+    endfunction
+
+    task display;
+      $display(
+              "x_req.instr_data = %x\n",  instr_data,
+              "x_req.rs1 = %x\n",         rs1,
+              "x_req.rs2 = %x\n",         rs2,
+              "x_req.rs3 = %x\n",         rs3,
+              "x_req.rs_valid = %x\n",    rs_valid,
+              "x_req.rd_clean = %x\n",    rd_clean,
+              "x_req.accept = %x\n",      accept,
+              "x_req.writeback = %x\n",   writeback,
+              "\n"
+            );
+    endtask
+
+  endclass
+
+
+  class x_rsp_t #(
+    parameter DataWidth = -1
+  );
+    // RSP Channel
+    rand logic [DataWidth-1:0] data0;
+    rand logic [DataWidth-1:0] data1;
+    rand logic                 error;
+    rand logic [4:0]           rd;
+    rand logic                 dual_writeback;
+
+    task display;
+      $display(
+              "x_rsp.data0 = %x\n",           data0,
+              "x_rsp.data1 = %x\n",           data1,
+              "x_rsp.error = %x\n",           error,
+              "x_rsp.rd = %x\n",              rd,
+              "x_rsp.dual_writeback = %x\n",  dual_writeback,
+              "\n"
+            );
+    endtask
+
+  endclass
+
+  class acc_x_driver #(
+    parameter int DataWidth = -1,
+    parameter time TA       = 0, // stimuli application time
+    parameter time TT       = 0  // stimuli test time
+  );
+
+    typedef x_req_t #(
+      .DataWidth ( DataWidth )
+    ) int_x_req_t;
+
+    typedef x_rsp_t #(
+      .DataWidth ( DataWidth )
+    ) int_x_rsp_t;
+
+    virtual ACC_X_BUS_DV #(
+      .DataWidth ( DataWidth )
+    ) bus;
+
+    function new(
+      virtual ACC_X_BUS_DV #(
+        .DataWidth ( DataWidth )
+      ) bus
+    );
+      this.bus=bus;
+    endfunction
+
+    task reset_master;
+      bus.q_instr_data <= '0;
+      bus.q_rs1        <= '0;
+      bus.q_rs2        <= '0;
+      bus.q_rs3        <= '0;
+      bus.q_rs_valid   <= '0;
+      bus.q_rd_clean   <= '0;
+      bus.q_valid      <= '0;
+      bus.p_ready      <= '0;
+    endtask
+
+    task reset_slave;
+      bus.q_ready          <= '0;
+      bus.k_accept         <= '0;
+      bus.k_writeback      <= '0;
+      bus.p_data0          <= '0;
+      bus.p_data1          <= '0;
+      bus.p_dual_writeback <= '0;
+      bus.p_rd             <= '0;
+      bus.p_error          <= '0;
+      bus.p_valid          <= '0;
+    endtask
+
+    task cycle_start;
+      #TT;
+    endtask
+
+    task cycle_end;
+      @(posedge bus.clk_i);
+    endtask
+
+    // Send a request
+    task send_req (inout int_x_req_t req);
+      bus.q_instr_data <= #TA req.instr_data;
+      bus.q_rs1        <= #TA req.rs1;
+      bus.q_rs2        <= #TA req.rs2;
+      bus.q_rs3        <= #TA req.rs3;
+      bus.q_rs_valid   <= #TA req.rs_valid;
+      bus.q_rd_clean   <= #TA req.rd_clean;
+      bus.q_valid      <= #TA 1;
+      cycle_start();
+      while (bus.q_ready != 1) begin
+        // update source regs and rs_valid
+        // rsx may change if valid bit not set
+        if (~req.rs_valid[0]) begin
+          assert(req.randomize(rs1));
+        end
+        if (~req.rs_valid[1]) begin
+          assert(req.randomize(rs2));
+        end
+        if (~req.rs_valid[2]) begin
+          assert(req.randomize(rs3));
+        end
+        assert(
+          req.randomize(rs_valid) with {
+            // valid rs may not become invalid.
+            foreach(rs_valid[i]) last_rs_valid[i] == 1 -> rs_valid[i] == 1;
+          }
+        );
+        assert(
+          req.randomize(rd_clean) with {
+            // clean rd may not become dirty during transaction.
+            foreach(rd_clean[i]) last_rd_clean[i] == 1 -> rd_clean[i] == 1;
+          }
+        );
+        bus.q_rs_valid <= #TA req.rs_valid;
+        bus.q_rd_clean <= #TA req.rd_clean;
+        bus.q_rs1      <= #TA req.rs1;
+        bus.q_rs2      <= #TA req.rs2;
+        bus.q_rs3      <= #TA req.rs3;
+        cycle_end();
+        cycle_start();
+      end
+      cycle_end();
+      bus.q_valid      <= #TA '0;
+      req.writeback = bus.k_writeback;
+      req.accept    = bus.k_accept;
+    endtask
+
+    // Send a response.
+    task send_rsp(input int_x_rsp_t rsp);
+      bus.p_data0          <= #TA rsp.data0;
+      bus.p_data1          <= #TA rsp.data1;
+      bus.p_dual_writeback <= #TA rsp.dual_writeback;
+      bus.p_rd             <= #TA rsp.rd;
+      bus.p_error          <= #TA rsp.error;
+      bus.p_valid          <= #TA 1;
+      cycle_start();
+      while (bus.p_ready != 1) begin cycle_end(); cycle_start(); end
+      cycle_end();
+      bus.p_data0          <= #TA '0;
+      bus.p_data1          <= #TA '0;
+      bus.p_dual_writeback <= #TA '0;
+      bus.p_rd             <= #TA '0;
+      bus.p_error          <= #TA '0;
+      bus.p_valid          <= #TA 0;
+    endtask
+
+    // Receive a request and send acknowlegment signals
+    task recv_req(inout int_x_req_t req);
+      bus.q_ready     <= #TA 1;
+      bus.k_accept    <= #TA req.accept;
+      bus.k_writeback <= #TA req.writeback;
+      while (bus.q_valid != 1) begin cycle_end(); cycle_start(); end
+      req            = new;
+      req.instr_data = bus.q_instr_data;
+      req.rs1        = bus.q_rs1;
+      req.rs2        = bus.q_rs2;
+      req.rs3        = bus.q_rs3;
+      req.rs_valid   = bus.q_rs_valid;
+      req.rd_clean   = bus.q_rd_clean;
+      cycle_end();
+      bus.q_ready     <= #TA 0;
+      bus.k_accept    <= #TA '0;
+      bus.k_writeback <= #TA '0;
+    endtask
+
+    // Receive a response.
+    task recv_rsp (output int_x_rsp_t rsp);
+      bus.p_ready <= #TA 1;
+      cycle_start();
+      while (bus.p_valid != 1) begin cycle_end(); cycle_start(); end
+      rsp                = new;
+      rsp.data0          = bus.p_data0;
+      rsp.data1          = bus.p_data1;
+      rsp.dual_writeback = bus.p_dual_writeback;
+      rsp.error          = bus.p_error;
+      rsp.rd             = bus.p_rd;
+      cycle_end();
+      bus.p_ready <= #TA 0;
+    endtask
+
+    // Monitor request
+    task mon_req (output int_x_req_t req);
+      cycle_start();
+      while (!(bus.q_valid && bus.q_ready)) begin cycle_end(); cycle_start(); end
+      req            = new;
+      req.instr_data = bus.q_instr_data;
+      req.rs1        = bus.q_rs1;
+      req.rs2        = bus.q_rs2;
+      req.rs3        = bus.q_rs3;
+      req.rs_valid   = bus.q_rs_valid;
+      req.rd_clean   = bus.q_rd_clean;
+      req.accept     = bus.k_accept;
+      req.writeback  = bus.k_writeback;
+      cycle_end();
+    endtask
+
+    // Monitor response.
+    task mon_rsp (output int_x_rsp_t rsp);
+      cycle_start();
+      while (!(bus.p_valid &&bus.p_ready)) begin cycle_end(); cycle_start(); end
+      rsp                = new;
+      rsp.data0          = bus.p_data0;
+      rsp.data1          = bus.p_data1;
+      rsp.dual_writeback = bus.p_dual_writeback;
+      rsp.error          = bus.p_error;
+      rsp.rd             = bus.p_rd;
+      cycle_end();
+    endtask
+
+  endclass
+
+  // Super Class for random x drivers
+  virtual class rand_x #(
+    // Acc Adapter interface parameters
+    parameter int DataWidth = -1,
+    // Stimuli application and test time
+    parameter time TA = 0ps,
+    parameter time TT = 0ps
+  );
+
+    typedef x_req_t #(
+      .DataWidth ( DataWidth )
+    ) int_x_req_t;
+
+    typedef x_rsp_t #(
+      .DataWidth ( DataWidth )
+    ) int_x_rsp_t;
+
+    typedef acc_test::acc_x_driver #(
+      .DataWidth ( DataWidth ),
+      .TA        ( TA        ),
+      .TT(TT)
+    ) acc_x_driver_t;
+
+    acc_x_driver_t drv;
+
+    function new(
+      virtual ACC_X_BUS_DV #(
+        .DataWidth ( DataWidth )
+      ) bus
+    );
+      this.drv = new(bus);
+    endfunction
+
+    task automatic rand_wait(input int unsigned min, input int unsigned max);
+      int unsigned rand_success, cycles;
+      rand_success = std::randomize(cycles) with {
+        cycles >= min;
+        cycles <= max;
+        // Weigh the distribution so that the minimum cycle time is the common
+        // case.
+        cycles dist {min := 10, [min+1:max] := 1};
+      };
+      assert (rand_success) else $error("Failed to randomize wait cycles!");
+      repeat (cycles) @(posedge this.drv.bus.clk_i);
+    endtask
+  endclass
+
+  class rand_x_master #(
+    parameter int DataWidth                    = -1,
+    parameter time         TA                  = 0ps,
+    parameter time         TT                  = 0ps,
+    parameter int unsigned REQ_MIN_WAIT_CYCLES = 1,
+    parameter int unsigned REQ_MAX_WAIT_CYCLES = 20,
+    parameter int unsigned RSP_MIN_WAIT_CYCLES = 1,
+    parameter int unsigned RSP_MAX_WAIT_CYCLES = 20
+  ) extends rand_x #(
+    .DataWidth ( DataWidth ),
+    .TA        ( TA        ),
+    .TT        ( TT        )
+  );
+
+    int unsigned cnt = 0;
+    bit req_done     = 0;
+
+    // Reset Driver
+    task reset();
+      drv.reset_master();
+    endtask
+
+    // Consructor
+    function new(
+      virtual ACC_X_BUS_DV #(
+        .DataWidth(DataWidth)
+      ) bus );
+      super.new(bus);
+    endfunction
+
+    task run (input int n);
+      fork
+        send_requests(n);
+        recv_response();
+      join
+    endtask
+
+    // Send random requests
+    task send_requests(input int n);
+      automatic int_x_req_t req = new;
+
+      repeat (n) begin
+        this.cnt++;
+        assert(req.randomize());
+        rand_wait(REQ_MIN_WAIT_CYCLES, REQ_MAX_WAIT_CYCLES);
+        this.drv.send_req(req);
+      end
+      this.req_done = 1;
+    endtask
+
+    // Receive response
+    task recv_response;
+      while (!this.req_done || this.cnt > 0) begin
+        automatic int_x_rsp_t rsp;
+        this.cnt--;
+        rand_wait(RSP_MIN_WAIT_CYCLES, RSP_MAX_WAIT_CYCLES);
+        this.drv.recv_rsp(rsp);
+      end
+    endtask
+  endclass
+
+  class rand_x_slave #(
+    parameter int DataWidth                    = -1,
+    parameter time         TA                  = 0ps,
+    parameter time         TT                  = 0ps,
+    parameter int unsigned REQ_MIN_WAIT_CYCLES = 1,
+    parameter int unsigned REQ_MAX_WAIT_CYCLES = 20,
+    parameter int unsigned RSP_MIN_WAIT_CYCLES = 1,
+    parameter int unsigned RSP_MAX_WAIT_CYCLES = 20
+  ) extends rand_x #(
+    .DataWidth(DataWidth),
+    .TA(TA),
+    .TT(TT)
+  );
+
+    mailbox req_mbx = new();
+
+    task recv_requests ();
+      forever begin
+        automatic int_x_req_t req;
+        rand_wait(REQ_MIN_WAIT_CYCLES, REQ_MAX_WAIT_CYCLES);
+        this.drv.recv_req(req);
+        if (req.k_writeback) begin
+          // put in mailbox if writeback expected
+          req_mbx.put(req);
+        end
+      end
+    endtask
+
+    task send_responses();
+      forever begin
+        automatic int_x_rsp_t rsp = new;
+        automatic int_x_req_t req;
+        req_mbx.get(req);
+        rand_wait(RSP_MIN_WAIT_CYCLES, RSP_MAX_WAIT_CYCLES);
+        this.drv.send_rsp(rsp);
+      end
+    endtask
+
+  endclass
+
+  class acc_x_monitor#(
+    parameter int DataWidth = -1,
+    parameter time TA       = 0ps,
+    parameter time TT       = 0ps
+  ) extends rand_x #(
+    .DataWidth(DataWidth),
+    .TA(TA),
+    .TT(TT)
+  );
+
+    mailbox req_mbx          = new();
+    mailbox rsp_mbx          = new();
+    mailbox req_mbx_rejected = new();
+
+    // Constructor
+    function new(
+      virtual ACC_X_BUS_DV #(
+        .DataWidth( DataWidth )
+      ) bus);
+      super.new(bus);
+    endfunction
+
+    // Monitor
+    task monitor;
+      fork
+        forever begin
+          automatic int_x_req_t req;
+          this.drv.mon_req(req);
+          if (req.accept) begin
+            req_mbx.put(req);
+          end else begin
+            req_mbx_rejected.put(req);
+          end
+        end
+        forever begin
+          int_x_rsp_t rsp;
+          this.drv.mon_rsp(rsp);
+          rsp_mbx.put(rsp);
+        end
+      join
+    endtask
+
+  endclass
+
+  // compare C / X interface responses
+  class compare_c_x_rsp #(
+    parameter type c_rsp_t = logic,
+    parameter type x_rsp_t = logic
+  );
+    static function do_compare(c_rsp_t c_rsp, x_rsp_t x_rsp);
+      return c_rsp.data0          == x_rsp.data0 &&
+             c_rsp.data1          == x_rsp.data1 &&
+             c_rsp.error          == x_rsp.error &&
+             c_rsp.rd             == x_rsp.rd    &&
+             c_rsp.dual_writeback == x_rsp.dual_writeback;
+    endfunction
+  endclass
+
+  ////////////////////////////////////////////
+  // Accelerator Predecoder Test Structures //
+  ////////////////////////////////////////////
+
+  class prd_rsp_t;
+    rand logic       accept;
+    rand logic [1:0] writeback;
+    rand logic [2:0] use_rs;
+
+    constraint accept_c {
+      accept == 1'b0 -> writeback == '0;
+      accept == 1'b0 -> use_rs == '0;
+    };
+
+    task display;
+      $display(
+              "prd_rsp.accept: %0d\n",     accept,
+              "prd_rsp.writeback: %0d\n",  writeback,
+              "prd_rsp.use_rs: %0d\n",     use_rs,
+              "\n"
+              );
+    endtask
+
+  endclass
+
+  class prd_req_t;
+    rand logic [31:0] instr_data;
+  endclass
+
+  class acc_prd_driver #(
+    parameter time TA = 0, // stimuli application time
+    parameter time TT = 0  // stimuli test time
+  );
+
+    virtual ACC_PRD_BUS_DV bus;
+
+    function new( virtual ACC_PRD_BUS_DV bus);
+      this.bus=bus;
+    endfunction
+
+    task reset_master;
+      bus.q_instr_data <= '0;
+    endtask
+
+    task reset_slave;
+      bus.p_accept    <= '0;
+      bus.p_writeback <= '0;
+      bus.p_use_rs    <= '0;
+    endtask
+
+    task cycle_start;
+      #TT;
+    endtask
+
+    task cycle_end;
+      @(posedge bus.clk_i);
+    endtask
+
+    // Send a request
+    task send_req (input prd_req_t req);
+      bus.q_instr_data <= #TA req.instr_data;
+    endtask
+
+    // Send a response
+    // Response is sent in the same cycle, a new request is detected
+    task send_rsp (input prd_rsp_t rsp);
+      // Predecoders respond entirely combinational
+      bus.p_accept    <= #TA rsp.accept;
+      bus.p_writeback <= #TA rsp.writeback;
+      bus.p_use_rs    <= #TA rsp.use_rs;
+      //cycle_end();
+    endtask
+
+    // This interface is passive; no recv task necessary
+
+    // request and response are generated at the same time.
+
+    task mon_reqrsp (output prd_req_t req, output prd_rsp_t rsp);
+      // record request and response at each change of instr_data input.
+      automatic logic [31:0] last_instr_data = bus.q_instr_data;
+      cycle_start();
+      while (bus.q_instr_data == last_instr_data) begin
+        cycle_end(); cycle_start();
+      end
+      req = new;
+      rsp = new;
+      req.instr_data = bus.q_instr_data;
+      rsp.accept     = bus.p_accept;
+      rsp.writeback  = bus.p_writeback;
+      rsp.use_rs     = bus.p_use_rs;
+      cycle_end();
+    endtask
+
+  endclass
+
+ class rand_prd #(
+    parameter time TA = 0ps,
+    parameter time TT = 0ps
+  );
+
+    typedef acc_test::acc_prd_driver #(
+      .TT(TT),
+      .TA(TA)
+    ) acc_prd_driver_t;
+
+    acc_prd_driver_t drv;
+
+    virtual ACC_PRD_BUS_DV bus;
+
+    function new (virtual ACC_PRD_BUS_DV bus);
+      this.drv = new(bus);
+    endfunction
+
+
+  endclass
+
+ // Collectively driving all predecoders. Easier to coordinate one-hot accept
+ // signal for adapter testbench.
+ class rand_prd_slave_collective #(
+    parameter NumRspTot = -1,
+    parameter time TA   = 0ps,
+    parameter time TT   = 0ps
+  );
+
+    typedef acc_test::acc_prd_driver #(
+      .TT(TT),
+      .TA(TA)
+    ) acc_prd_driver_t;
+
+    acc_prd_driver_t drv[NumRspTot];
+
+    virtual ACC_PRD_BUS_DV bus [NumRspTot];
+
+    function new ( virtual ACC_PRD_BUS_DV bus [NumRspTot] );
+      foreach(this.drv[ii]) this.drv[ii] = new(bus[ii]);
+    endfunction
+
+    rand logic [NumRspTot-1:0] accept_onehot;
+
+    task reset();
+      foreach(this.drv[ii]) drv[ii].reset_slave();
+    endtask
+
+    task wait_instr();
+      @(drv[0].bus.q_instr_data);
+    endtask
+
+    task run();
+      // We generate random responses, not caring about the exact request.
+      automatic prd_rsp_t prd_rsp[NumRspTot];
+      forever begin
+
+        assert(std::randomize(accept_onehot) with {
+            $countones(accept_onehot) <= 1;
+          }
+        );
+        for (int i=0; i<NumRspTot; i++) begin
+
+          prd_rsp[i] = new;
+          assert(
+            prd_rsp[i].randomize with {
+              accept == accept_onehot[i];
+            }
+          );
+        end
+
+        for (int i=0; i<NumRspTot; i++) begin
+          fork
+            automatic int ii=i;
+            //$display("Time: %0t, Fork: %0d", $time, ii);
+            this.drv[ii].send_rsp(prd_rsp[ii]);
+          join_none
+        end
+        @(drv[0].bus.q_instr_data);
+      end
+    endtask
+  endclass
+
+  class acc_prd_monitor #(
+    parameter time TA = 0ps,
+    parameter time TT = 0ps
+  ) extends rand_prd #(
+    .TA(TA),
+    .TT(TT)
+  );
+
+    // Constructor.
+    function new (virtual ACC_PRD_BUS_DV bus);
+      super.new(bus);
+    endfunction
+
+    mailbox rsp_mbx = new;
+    mailbox req_mbx = new;
+
+    // Record req and rsp for accepted instructions
+    task monitor;
+      forever begin
+        automatic prd_req_t req;
+        automatic prd_rsp_t rsp;
+        this.drv.mon_reqrsp(req, rsp);
+        if (rsp.accept) begin
+          req_mbx.put(req);
+          rsp_mbx.put(rsp);
+        end
+      end
+    endtask
+
+  endclass
+
+  class adp_check_req #(
+    parameter type acc_c_req_t = logic,
+    parameter type acc_x_req_t = logic,
+    parameter type acc_prd_rsp_t = logic
+  );
+
+    // Check construction of interconnect request from predecoder response
+    // + adapter request.
+    static function do_check (acc_x_req_t x_req, acc_prd_rsp_t prd_rsp, acc_c_req_t c_req);
+
+      // Check result (Address is checked externally.
+      return (c_req.data_arga == (prd_rsp.use_rs[0] ? x_req.rs1 : '0)) &&
+             (c_req.data_argb == (prd_rsp.use_rs[1] ? x_req.rs2 : '0)) &&
+             (c_req.data_argc == (prd_rsp.use_rs[2] ? x_req.rs3 : '0)) &&
+             (c_req.id        == 1'b0)                                 &&
+             (c_req.data_op   == x_req.instr_data);
+
+    endfunction
+  endclass
+
+
+endpackage

--- a/src/acc_test.sv
+++ b/src/acc_test.sv
@@ -14,24 +14,18 @@ package acc_test;
 
   class c_req_t #(
     parameter int AddrWidth = -1,
-    parameter int DataWidth = -1,
-    parameter int IdWidth   = -1
+    parameter int DataWidth = -1
   );
     rand logic [AddrWidth-1:0] addr;
     rand logic [DataWidth-1:0] data_arga;
     rand logic [DataWidth-1:0] data_argb;
     rand logic [DataWidth-1:0] data_argc;
     rand logic [31:0]          data_op;
-    rand logic [IdWidth-1:0]   id;
-
-    constraint id_lsb_c {
-      id[0] == 1'b0;
-    };
+    rand logic [31:0]          hart_id;
 
     typedef c_req_t # (
       .AddrWidth ( AddrWidth ),
-      .DataWidth ( DataWidth ),
-      .IdWidth   ( IdWidth   )
+      .DataWidth ( DataWidth )
     ) int_c_req_t;
 
     function do_compare (int_c_req_t req);
@@ -39,7 +33,8 @@ package acc_test;
              data_arga == req.data_arga &&
              data_argb == req.data_argb &&
              data_argc == req.data_argc &&
-             data_op   == req.data_op;
+             data_op   == req.data_op   &&
+             hart_id   == req.hart_id;
     endfunction
 
     task display;
@@ -49,52 +44,34 @@ package acc_test;
               "c_req.data_arga: %x\n",  data_arga,
               "c_req.data_argb: %x\n",  data_argb,
               "c_req.data_argc: %x\n",  data_argc,
-              "c_req.id: %x\n",         id,
+              "c_req.hart_id: %x\n",    hart_id,
               "\n"
             );
     endtask
   endclass
 
-  // Compare C requests of different parameterizations.
-  // different parametrizations
-  class compare_c_req #(
-    parameter type mst_c_req_t = logic,
-    parameter type slv_c_req_t = logic
-  );
-    static function do_compare(mst_c_req_t mst_req, slv_c_req_t slv_req);
-      return mst_req.addr      == slv_req.addr      &&
-             mst_req.data_arga == slv_req.data_arga &&
-             mst_req.data_argb == slv_req.data_argb &&
-             mst_req.data_argc == slv_req.data_argc &&
-             mst_req.data_op   == slv_req.data_op;
-    endfunction
-  endclass
-
-
   class c_rsp_t #(
-    parameter int DataWidth = -1,
-    parameter int IdWidth   = -1
+    parameter int DataWidth = -1
   );
     rand logic [DataWidth-1:0] data0;
     rand logic [DataWidth-1:0] data1;
     rand logic                 dual_writeback;
     rand logic                 error;
-    logic [4:0]                rd; // not random!
-    logic [IdWidth-1:0]        id;
+    logic [4:0]                rd;
+    logic [31:0]               hart_id;
 
     typedef c_rsp_t # (
-      .DataWidth    ( DataWidth ),
-      .IdWidth      ( IdWidth   )
+      .DataWidth    ( DataWidth )
     ) int_c_rsp_t;
 
     task display;
       $display(
-              "c_rsp.data0: %x\n",          data0,
-              "c_rsp.data1: %x\n",          data1,
-              "c_rsp.dual_writeback: %x\n", dual_writeback,
-              "c_rsp.error %x\n",           error,
-              "c_rsp.rd: %x\n",             rd,
-              "c_rsp.id: %x\n",             id,
+              "c_rsp.data0: %x\n",           data0,
+              "c_rsp.data1: %x\n",           data1,
+              "c_rsp.dual_writeback: %x\n",  dual_writeback,
+              "c_rsp.error %x\n",            error,
+              "c_rsp.rd: %x\n",              rd,
+              "c_rsp.hart_id: %x\n",         hart_id,
               "\n"
             );
     endtask
@@ -104,58 +81,48 @@ package acc_test;
              data1          == rsp.data1          &
              dual_writeback == rsp.dual_writeback &
              error          == rsp.error          &
-             rd             == rsp.rd;
-    endfunction
-  endclass
-
-
-  // Compare rsps of different parameterizations.
-  class compare_c_rsp #(
-    parameter type mst_c_rsp_t = logic,
-    parameter type slv_c_rsp_t = logic
-  );
-    static function do_compare(mst_c_rsp_t mst_rsp, slv_c_rsp_t slv_rsp);
-      return mst_rsp.data0          == slv_rsp.data0          &
-             mst_rsp.data1          == slv_rsp.data1          &
-             mst_rsp.dual_writeback == slv_rsp.dual_writeback &
-             mst_rsp.error          == slv_rsp.error          &
-             mst_rsp.rd             == slv_rsp.rd;
+             rd             == rsp.rd             &
+             hart_id        == rsp.hart_id;
     endfunction
   endclass
 
   class acc_c_driver #(
     parameter int AddrWidth = -1,
     parameter int DataWidth = -1,
-    parameter int IdWidth   = -1,
     parameter time TA       = 0, // stimuli application time
     parameter time TT       = 0  // stimuli test time
   );
 
     typedef c_req_t #(
       .DataWidth ( DataWidth ),
-      .AddrWidth ( AddrWidth ),
-      .IdWidth   ( IdWidth   )
+      .AddrWidth ( AddrWidth )
     ) int_c_req_t;
 
     typedef c_rsp_t #(
-      .DataWidth ( DataWidth ),
-      .IdWidth   ( IdWidth   )
+      .DataWidth ( DataWidth )
     ) int_c_rsp_t;
 
     virtual ACC_C_BUS_DV # (
       .DataWidth ( DataWidth ),
-      .AddrWidth ( AddrWidth ),
-      .IdWidth   ( IdWidth   )
+      .AddrWidth ( AddrWidth )
     ) bus;
 
+    logic [31:0] hart_id;
+    bit const_hart_id;
+
+    // Initialiation variable hart_id:
+    // hart_id == -1 -> variable request hart id
+    // hart_id >=  0 -> hart id hardwired.
     function new(
       virtual ACC_C_BUS_DV #(
         .DataWidth ( DataWidth ),
-        .AddrWidth ( AddrWidth ),
-        .IdWidth   ( IdWidth   )
-      ) bus
+        .AddrWidth ( AddrWidth )
+      ) bus,
+      int hart_id = -1
     );
-      this.bus=bus;
+      this.bus = bus;
+      this.const_hart_id = ( hart_id >= 0 );
+      this.hart_id = 32'(unsigned'(hart_id));
     endfunction
 
     task reset_master;
@@ -164,7 +131,7 @@ package acc_test;
       bus.q_data_arga <= '0;
       bus.q_data_argb <= '0;
       bus.q_data_argc <= '0;
-      bus.q_id        <= '0;
+      bus.q_hart_id   <= const_hart_id ? hart_id : '0;
       bus.q_valid     <= '0;
       bus.p_ready     <= '0;
     endtask
@@ -173,7 +140,7 @@ package acc_test;
       bus.p_data0          <= '0;
       bus.p_data1          <= '0;
       bus.p_dual_writeback <= '0;
-      bus.p_id             <= '0;
+      bus.p_hart_id        <= '0;
       bus.p_rd             <= '0;
       bus.p_error          <= '0;
       bus.p_valid          <= '0;
@@ -190,12 +157,16 @@ package acc_test;
 
     // Send a request.
     task send_req (input int_c_req_t req);
+      if (const_hart_id) begin
+        assert(req.hart_id == hart_id) else
+          $error("req.hart_id = %0x, sender.hart_id = %0x", req.hart_id, hart_id);
+      end
       bus.q_addr      <= #TA req.addr;
       bus.q_data_op   <= #TA req.data_op;
       bus.q_data_arga <= #TA req.data_arga;
       bus.q_data_argb <= #TA req.data_argb;
       bus.q_data_argc <= #TA req.data_argc;
-      bus.q_id        <= #TA req.id;
+      bus.q_hart_id   <= #TA req.hart_id;
       bus.q_valid     <= #TA 1;
       cycle_start();
       while (bus.q_ready != 1) begin cycle_end(); cycle_start(); end
@@ -205,7 +176,7 @@ package acc_test;
       bus.q_data_arga <= #TA '0;
       bus.q_data_argb <= #TA '0;
       bus.q_data_argc <= #TA '0;
-      bus.q_id        <= #TA '0;
+      bus.q_hart_id   <= #TA const_hart_id ? hart_id : '0;
       bus.q_valid     <= #TA  0;
     endtask
 
@@ -214,7 +185,7 @@ package acc_test;
       bus.p_data0          <= #TA rsp.data0;
       bus.p_data1          <= #TA rsp.data1;
       bus.p_dual_writeback <= #TA rsp.dual_writeback;
-      bus.p_id             <= #TA rsp.id;
+      bus.p_hart_id        <= #TA rsp.hart_id;
       bus.p_rd             <= #TA rsp.rd;
       bus.p_error          <= #TA rsp.error;
       bus.p_valid          <= #TA 1;
@@ -224,7 +195,7 @@ package acc_test;
       bus.p_data0          <= #TA '0;
       bus.p_data1          <= #TA '0;
       bus.p_dual_writeback <= #TA '0;
-      bus.p_id             <= #TA '0;
+      bus.p_hart_id        <= #TA '0;
       bus.p_rd             <= #TA '0;
       bus.p_error          <= #TA '0;
       bus.p_valid          <= #TA 0;
@@ -241,7 +212,7 @@ package acc_test;
       req.data_arga = bus.q_data_arga;
       req.data_argb = bus.q_data_argb;
       req.data_argc = bus.q_data_argc;
-      req.id        = bus.q_id;
+      req.hart_id   = bus.q_hart_id;
       cycle_end();
       bus.q_ready <= #TA 0;
     endtask
@@ -256,7 +227,7 @@ package acc_test;
       rsp.data1          = bus.p_data1;
       rsp.dual_writeback = bus.p_dual_writeback;
       rsp.error          = bus.p_error;
-      rsp.id             = bus.p_id;
+      rsp.hart_id        = bus.p_hart_id;
       rsp.rd             = bus.p_rd;
       cycle_end();
       bus.p_ready <= #TA 0;
@@ -272,7 +243,7 @@ package acc_test;
       req.data_arga = bus.q_data_arga;
       req.data_argb = bus.q_data_argb;
       req.data_argc = bus.q_data_argc;
-      req.id        = bus.q_id;
+      req.hart_id   = bus.q_hart_id;
       cycle_end();
     endtask
 
@@ -285,7 +256,7 @@ package acc_test;
       rsp.data1          = bus.p_data1;
       rsp.dual_writeback = bus.p_dual_writeback;
       rsp.error          = bus.p_error;
-      rsp.id             = bus.p_id;
+      rsp.hart_id        = bus.p_hart_id;
       rsp.rd             = bus.p_rd;
       cycle_end();
     endtask
@@ -295,45 +266,39 @@ package acc_test;
   // Super classes for random acc drivers
   virtual class rand_c #(
     // Acc interface parameters
-    parameter int DataWidth    = -1,
-    parameter int AddrWidth    = -1,
-    parameter int IdWidth      = -1,
-
+    parameter int DataWidth = -1,
+    parameter int AddrWidth = -1,
     // Stimuli application and test time
     parameter time TA = 0ps,
     parameter time TT = 0ps
   );
 
     typedef c_req_t #(
-      .AddrWidth    ( AddrWidth    ),
-      .DataWidth    ( DataWidth    ),
-      .IdWidth      ( IdWidth      )
+      .AddrWidth ( AddrWidth ),
+      .DataWidth ( DataWidth )
     ) int_c_req_t;
 
     typedef c_rsp_t #(
-      .DataWidth    ( DataWidth  ),
-      .IdWidth      ( IdWidth    )
+      .DataWidth    ( DataWidth )
     ) int_c_rsp_t;
 
     typedef acc_test::acc_c_driver #(
-      // Acc interface parameters
-      .AddrWidth    ( AddrWidth    ),
-      .DataWidth    ( DataWidth    ),
-      .IdWidth      ( IdWidth      ),
-      // Stimuli application and test time
-      .TA(TA),
-      .TT(TT)
+      .AddrWidth ( AddrWidth ),
+      .DataWidth ( DataWidth ),
+      .TA        ( TA        ),
+      .TT        ( TT        )
     ) acc_c_driver_t;
 
     acc_c_driver_t drv;
 
     function new(
       virtual ACC_C_BUS_DV #(
-        .DataWidth    ( DataWidth    ),
-        .AddrWidth    ( AddrWidth    ),
-        .IdWidth      ( IdWidth      )
-      ) bus );
-      this.drv = new (bus);
+        .DataWidth ( DataWidth ),
+        .AddrWidth ( AddrWidth )
+      ) bus,
+      int hart_id = -1
+    );
+      this.drv = new (bus, hart_id);
     endfunction
 
     task automatic rand_wait(input int unsigned min, input int unsigned max);
@@ -351,13 +316,19 @@ package acc_test;
 
   endclass
 
+  class rand_hart_id;
+    rand int hart_id;
+    constraint positive_hart_id_c {
+      hart_id >= 0;
+    }
+  endclass
+
   // Generate random requests as a master device.
   class rand_c_master #(
     // Acc interface parameters
     parameter int DataWidth       = -1,
     parameter int AccAddrWidth    = -1,
     parameter int AddrWidth       = -1,
-    parameter int IdWidth         = -1,
     parameter int NumHier         = -1,
     parameter int HierLevel       = -1,
     parameter int NumRsp[NumHier] = '{-1},
@@ -369,13 +340,10 @@ package acc_test;
     parameter int unsigned RSP_MIN_WAIT_CYCLES = 1,
     parameter int unsigned RSP_MAX_WAIT_CYCLES = 20
   ) extends rand_c #(
-      // Acc interface parameters
       .DataWidth ( DataWidth ),
       .AddrWidth ( AddrWidth ),
-      .IdWidth   ( IdWidth   ),
-      // Stimuli application and test time
-      .TA ( TA ),
-      .TT ( TT )
+      .TA        ( TA        ),
+      .TT        ( TT        )
     );
 
     int unsigned cnt = 0;
@@ -390,10 +358,11 @@ package acc_test;
     function new (
       virtual ACC_C_BUS_DV #(
         .DataWidth ( DataWidth ),
-        .AddrWidth ( AddrWidth ),
-        .IdWidth   ( IdWidth   )
-      ) bus );
-      super.new(bus);
+        .AddrWidth ( AddrWidth )
+      ) bus,
+      int hart_id
+    );
+      super.new(bus, hart_id);
     endfunction
 
     task run(input int n);
@@ -415,6 +384,7 @@ package acc_test;
             addr[AccAddrWidth-1:0]         inside {[0:NumRsp[addr[AddrWidth-1:AccAddrWidth]]-1]};
           }
         );
+        if (drv.const_hart_id) req.hart_id = drv.hart_id;
         rand_wait(REQ_MIN_WAIT_CYCLES, REQ_MAX_WAIT_CYCLES);
         this.drv.send_req(req);
       end
@@ -432,29 +402,159 @@ package acc_test;
     endtask
   endclass
 
+  // The slave modules do not know the hart_ids connected to it.
+  // Therefore we cannot directly index into the mailbox array.
+  // know the exact hart ids connected to it.
+  // This class facilitates automatic mapping of hart_ids to corresponding
+  // mailboxes.
+  class mailbox_container #(
+    parameter int  NumMbx = -1,
+    parameter type msg_t  = logic,
+    parameter type idx_t  = logic
+  );
+    mailbox mbx[NumMbx];
+    int unsigned mbx_pointer[idx_t];
+    int unsigned idx_pointer[logic[cf_math_pkg::idx_width(NumMbx)-1:0]];
+    int unsigned mbx_next = 0;
+
+    // This event is triggered once a mailbox is assigned a hart_id.
+    // `get` functions waiting for specific hart_id mailboxes must wait for
+    // this assignement to happen.
+    event e_mbx_assigned [logic[31:0]];
+
+    function new;
+      foreach (mbx[ii]) mbx[ii] = new;
+    endfunction
+
+    function automatic event new_event();
+      event e;
+      return e;
+    endfunction
+
+    task put(input msg_t msg, input idx_t idx);
+      if (!mbx_pointer.exists(idx)) begin
+        if(!e_mbx_assigned.exists(idx)) begin
+          this.e_mbx_assigned[idx] = new_event();
+        end
+        assert(mbx_next <= NumMbx);
+        mbx_pointer[idx] = mbx_next;
+        idx_pointer[mbx_next] = idx;
+        -> e_mbx_assigned[idx];
+        mbx_next++;
+      end
+      mbx[mbx_pointer[idx]].put(msg);
+    endtask
+
+    function automatic int num(idx_t idx);
+      if (!mbx_pointer.exists(idx)) begin
+        return 0;
+      end else begin
+        return mbx[mbx_pointer[idx]].num();
+      end
+    endfunction
+
+    function automatic int num_direct(int i);
+      assert(i < NumMbx);
+      return mbx[i].num();
+    endfunction
+
+    task get(output msg_t msg, input idx_t idx);
+      if (!mbx_pointer.exists(idx)) begin
+        if(!e_mbx_assigned.exists(idx)) begin
+          this.e_mbx_assigned[idx] = new_event();
+        end
+        @(e_mbx_assigned[idx]);
+        assert(mbx_pointer.exists(idx));
+      end
+      mbx[mbx_pointer[idx]].get(msg);
+    endtask
+
+    task get_direct(output msg_t msg, input int i);
+      assert(i < NumMbx);
+      mbx[i].get(msg);
+    endtask
+
+    task peek(output msg_t msg, input idx_t idx);
+      if (!mbx_pointer.exists(idx)) begin
+        @(e_mbx_assigned[idx]);
+        assert(mbx_pointer.exists(idx));
+      end
+      msg=new;
+      mbx[mbx_pointer[idx]].peek(msg);
+    endtask
+
+    task peek_direct(output msg_t msg, input int i);
+      assert(i < NumMbx);
+      mbx[i].peek(msg);
+    endtask
+    function try_get(output msg_t msg, input idx_t idx);
+      if (!mbx_pointer.exists(idx)) begin
+        return 0;
+      end
+      return mbx[mbx_pointer[idx]].try_get(msg);
+    endfunction
+
+    // try_get message from random mailbox, if any.
+    function automatic bit try_get_random(output msg_t msg);
+      automatic int mbx_id[NumMbx];
+      automatic bit msg_found = 1'b0;
+      for (int i = 0; i < NumMbx; i++) begin
+        mbx_id[i] = i;
+      end
+      mbx_id.shuffle();
+      for (int i = 0; i < NumMbx; i++) begin
+        if(idx_pointer.exists(mbx_id[i])) begin
+          msg_found |= try_get(msg, idx_pointer[mbx_id[i]]);
+        end
+        if (msg_found) break;
+      end
+      return msg_found;
+    endfunction
+
+    function automatic bit empty();
+      automatic bit result = 1;
+      for (int i = 0; i < NumMbx; i++) begin
+        result &= (mbx[i].num() == 0);
+      end
+      return result;
+    endfunction
+
+  endclass
+
   class rand_c_slave #(
     // Acc interface parameters
     parameter int AddrWidth    = -1,
     parameter int DataWidth    = -1,
-    parameter int IdWidth      = -1,
+    parameter int NumReq       = -1,
     // Stimuli application and test time
-    parameter time  TA = 0ps,
-    parameter time  TT = 0ps,
     parameter int unsigned REQ_MIN_WAIT_CYCLES = 0,
     parameter int unsigned REQ_MAX_WAIT_CYCLES = 10,
     parameter int unsigned RSP_MIN_WAIT_CYCLES = 0,
-    parameter int unsigned RSP_MAX_WAIT_CYCLES = 10
+    parameter int unsigned RSP_MAX_WAIT_CYCLES = 10,
+    parameter time TA = 0ps,
+    parameter time TT = 0ps
   ) extends rand_c #(
-      // Acc interface parameters
       .AddrWidth ( AddrWidth ),
       .DataWidth ( DataWidth ),
-      .IdWidth   ( IdWidth   ),
-      // Stimuli application and test time
-      .TA(TA),
-      .TT(TT)
+      .TA        ( TA        ),
+      .TT        ( TT        )
     );
 
-    mailbox req_mbx[2**IdWidth];
+    mailbox_container #(
+        .NumMbx ( NumReq      ),
+        .msg_t  ( int_c_req_t ),
+        .idx_t  ( logic[31:0] )
+      ) req_mbx_cnt;
+
+    /// Constructor.
+    function new (
+      virtual ACC_C_BUS_DV #(
+        .DataWidth ( DataWidth ),
+        .AddrWidth ( AddrWidth )
+      ) bus);
+      super.new(bus);
+      req_mbx_cnt = new;
+    endfunction
 
     /// Reset the driver.
     task reset();
@@ -468,53 +568,28 @@ package acc_test;
       join
     endtask
 
-    /// Constructor.
-    function new (
-      virtual ACC_C_BUS_DV #(
-        .DataWidth    ( DataWidth    ),
-        .AddrWidth    ( AddrWidth    ),
-        .IdWidth      ( IdWidth      )
-      ) bus);
-      super.new(bus);
-      foreach(this.req_mbx[ii]) req_mbx[ii] = new();
-    endfunction
-
     task recv_requests();
       forever begin
         automatic int_c_req_t req;
         rand_wait(REQ_MIN_WAIT_CYCLES, REQ_MAX_WAIT_CYCLES);
         this.drv.recv_req(req);
-        req_mbx[req.id >> 1].put(req);
+        req_mbx_cnt.put(req, req.hart_id);
       end
     endtask
 
+    // Generate and send random response.
+    // The order in which requests from different origins are served is randomized
     task send_responses();
       forever begin
         automatic int_c_rsp_t rsp = new;
         automatic int_c_req_t req;
-        // generate random sequence of requesters.
-        automatic int req_id[2**IdWidth];
-        automatic bit req_found = 1'b0;
-        // randomly pick a request
-        for (int i =0; i<2**IdWidth; i++) begin
-          req_id[i] = i;
-        end
-        req_id.shuffle();
-        for (int i=0; i<2**IdWidth; i++) begin
-          automatic int r_id = req_id[i];
-          if (req_mbx[r_id].num() != 0) begin
-            req_mbx[r_id].get(req);
-            req_found = 1'b1;
-            break;
-          end
-        end
+        automatic bit req_found;
+        // get request from random requester mailbox.
+        req_found = req_mbx_cnt.try_get_random(req);
         if (req_found==1'b1) begin
-          // generate and send random response.
           assert(rsp.randomize());
-          // get Id + Rd from corresponding request.
-          rsp.id = req.id;
+          rsp.hart_id = req.hart_id;
           rsp.rd = req.data_op[11:7];
-          // send response back to requester.
           @(posedge this.drv.bus.clk_i);
           rand_wait(RSP_MIN_WAIT_CYCLES, RSP_MAX_WAIT_CYCLES);
           this.drv.send_rsp(rsp);
@@ -527,51 +602,56 @@ package acc_test;
 
   class acc_c_slv_monitor #(
     // Acc interface parameters
-    parameter int DataWidth    = -1,
-    parameter int AddrWidth    = -1,
-    parameter int IdWidth      = -1,
+    parameter int DataWidth = -1,
+    parameter int AddrWidth = -1,
+    parameter int NumReq    = -1,
     // Stimuli application and test time
     parameter time  TA = 0ps,
     parameter time  TT = 0ps
   ) extends rand_c #(
-        .DataWidth    ( DataWidth    ),
-        .AddrWidth    ( AddrWidth    ),
-        .IdWidth      ( IdWidth      ),
-        .TA           ( TA           ),
-        .TT           ( TT           )
+        .DataWidth ( DataWidth ),
+        .AddrWidth ( AddrWidth ),
+        .TA        ( TA        ),
+        .TT        ( TT        )
   );
 
-    mailbox req_mbx[IdWidth**2];
-    mailbox rsp_mbx[IdWidth**2];
+    mailbox_container #(
+        .NumMbx ( NumReq      ),
+        .msg_t  ( int_c_req_t ),
+        .idx_t  ( logic[31:0] )
+      ) req_mbx_cnt;
+
+    mailbox_container #(
+        .NumMbx ( NumReq      ),
+        .msg_t  ( int_c_rsp_t ),
+        .idx_t  ( logic[31:0] )
+      ) rsp_mbx_cnt;
 
     // Constructor.
     function new (
       virtual ACC_C_BUS_DV #(
-        .DataWidth    ( DataWidth    ),
-        .AddrWidth    ( AddrWidth    ),
-        .IdWidth      ( IdWidth      )
+        .DataWidth ( DataWidth ),
+        .AddrWidth ( AddrWidth )
       ) bus);
       super.new(bus);
-      foreach (this.req_mbx[ii]) req_mbx[ii] = new();
-      foreach (this.rsp_mbx[ii]) rsp_mbx[ii] = new();
-
+      req_mbx_cnt = new;
+      rsp_mbx_cnt = new;
     endfunction
 
     // Slave Monitor.
-    // For each master maintain a separate mailbox.
     task monitor;
       fork
         forever begin
           automatic int_c_req_t req;
           this.drv.mon_req(req);
           // put in req mbox corresponding to the requester
-          req_mbx[req.id].put(req);
+          req_mbx_cnt.put(req, req.hart_id);
         end
         forever begin
           automatic int_c_rsp_t rsp;
           this.drv.mon_rsp(rsp);
           // put in req mbox corresponding to the requester
-          rsp_mbx[rsp.id].put(rsp);
+          rsp_mbx_cnt.put(rsp, rsp.hart_id);
         end
       join
     endtask
@@ -582,7 +662,6 @@ package acc_test;
     parameter int DataWidth    = -1,
     parameter int AddrWidth    = -1,
     parameter int AccAddrWidth = -1,
-    parameter int IdWidth      = -1,
     parameter int HierLevel    = -1,
     // Stimuli application and test time
     parameter time  TA = 0ps,
@@ -590,12 +669,11 @@ package acc_test;
   ) extends rand_c #(
         .DataWidth ( DataWidth ),
         .AddrWidth ( AddrWidth ),
-        .IdWidth   ( IdWidth   ),
         .TA        ( TA        ),
         .TT        ( TT        )
     );
 
-    mailbox req_mbx [AccAddrWidth**2];
+    mailbox req_mbx[AccAddrWidth**2];
     mailbox req_mbx_fwd = new;
     mailbox rsp_mbx = new;
 
@@ -603,8 +681,7 @@ package acc_test;
     function new (
       virtual ACC_C_BUS_DV #(
         .DataWidth ( DataWidth ),
-        .AddrWidth ( AddrWidth ),
-        .IdWidth   ( IdWidth   )
+        .AddrWidth ( AddrWidth )
       ) bus);
       super.new(bus);
       foreach (this.req_mbx[ii]) req_mbx[ii] = new;
@@ -617,7 +694,6 @@ package acc_test;
         forever begin
           automatic int_c_req_t req;
           this.drv.mon_req(req);
-          //req.display();
           // Check if request addresses this level
           if (req.addr[AddrWidth-1:AccAddrWidth] == HierLevel) begin
             // put in req mbox corresponding to the responder
@@ -680,7 +756,7 @@ package acc_test;
 
 
   class x_rsp_t #(
-    parameter DataWidth = -1
+    parameter int DataWidth = -1
   );
     // RSP Channel
     rand logic [DataWidth-1:0] data0;
@@ -802,7 +878,7 @@ package acc_test;
         cycle_start();
       end
       cycle_end();
-      bus.q_valid      <= #TA '0;
+      bus.q_valid  <= #TA '0;
       req.writeback = bus.k_writeback;
       req.accept    = bus.k_accept;
     endtask
@@ -846,7 +922,7 @@ package acc_test;
     endtask
 
     // Receive a response.
-    task recv_rsp (output int_x_rsp_t rsp);
+    task recv_rsp(output int_x_rsp_t rsp);
       bus.p_ready <= #TA 1;
       cycle_start();
       while (bus.p_valid != 1) begin cycle_end(); cycle_start(); end
@@ -1210,15 +1286,14 @@ package acc_test;
       this.drv = new(bus);
     endfunction
 
-
   endclass
 
  // Collectively driving all predecoders. Easier to coordinate one-hot accept
  // signal for adapter testbench.
  class rand_prd_slave_collective #(
-    parameter NumRspTot = -1,
-    parameter time TA   = 0ps,
-    parameter time TT   = 0ps
+    parameter int NumRspTot = -1,
+    parameter time TA       = 0ps,
+    parameter time TT       = 0ps
   );
 
     typedef acc_test::acc_prd_driver #(
@@ -1230,7 +1305,7 @@ package acc_test;
 
     virtual ACC_PRD_BUS_DV bus [NumRspTot];
 
-    function new ( virtual ACC_PRD_BUS_DV bus [NumRspTot] );
+    function new (virtual ACC_PRD_BUS_DV bus[NumRspTot]);
       foreach(this.drv[ii]) this.drv[ii] = new(bus[ii]);
     endfunction
 
@@ -1254,7 +1329,6 @@ package acc_test;
           }
         );
         for (int i=0; i<NumRspTot; i++) begin
-
           prd_rsp[i] = new;
           assert(
             prd_rsp[i].randomize with {
@@ -1266,7 +1340,6 @@ package acc_test;
         for (int i=0; i<NumRspTot; i++) begin
           fork
             automatic int ii=i;
-            //$display("Time: %0t, Fork: %0d", $time, ii);
             this.drv[ii].send_rsp(prd_rsp[ii]);
           join_none
         end
@@ -1307,8 +1380,8 @@ package acc_test;
   endclass
 
   class adp_check_req #(
-    parameter type acc_c_req_t = logic,
-    parameter type acc_x_req_t = logic,
+    parameter type acc_c_req_t   = logic,
+    parameter type acc_x_req_t   = logic,
     parameter type acc_prd_rsp_t = logic
   );
 
@@ -1320,7 +1393,6 @@ package acc_test;
       return (c_req.data_arga == (prd_rsp.use_rs[0] ? x_req.rs1 : '0)) &&
              (c_req.data_argb == (prd_rsp.use_rs[1] ? x_req.rs2 : '0)) &&
              (c_req.data_argc == (prd_rsp.use_rs[2] ? x_req.rs3 : '0)) &&
-             (c_req.id        == 1'b0)                                 &&
              (c_req.data_op   == x_req.instr_data);
 
     endfunction

--- a/test/acc_adapter_tb.sv
+++ b/test/acc_adapter_tb.sv
@@ -1,0 +1,344 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Noam Gallmann <gnoam@live.com>
+
+`include "acc_interface/assign.svh"
+`include "acc_interface/typedef.svh"
+
+module acc_adapter_tb #(
+  parameter int unsigned DataWidth       = 32,
+  parameter int unsigned NumHier         = 3,
+  parameter int unsigned NumRsp[NumHier] = '{4,2,2},
+  parameter int unsigned NumRspTot       = sumn(NumRsp, NumHier),
+  // TB Params
+  parameter int unsigned NrRandomTransactions = 1000
+);
+
+  import acc_pkg::*;
+  localparam int unsigned MaxNumRsp     = maxn(NumRsp, NumHier);
+  localparam int unsigned HierAddrWidth = cf_math_pkg::idx_width(NumHier);
+  localparam int unsigned AccAddrWidth  = cf_math_pkg::idx_width(MaxNumRsp);
+  localparam int unsigned AddrWidth     = HierAddrWidth + AccAddrWidth;
+
+  // Timing params
+  localparam time ClkPeriod = 10ns;
+  localparam time ApplTime  = 2ns;
+  localparam time TestTime  = 8ns;
+
+  logic clk, rst_n;
+
+  // ----------------
+  // Clock generation
+  // ----------------
+  initial begin
+    rst_n = 0;
+    repeat (3) begin
+      #(ClkPeriod/2) clk = 0;
+      #(ClkPeriod/2) clk = 1;
+    end
+    rst_n = 1;
+    forever begin
+      #(ClkPeriod/2) clk = 0;
+      #(ClkPeriod/2) clk = 1;
+    end
+  end
+
+  typedef acc_test::c_req_t # (
+    .AddrWidth ( AddrWidth ),
+    .DataWidth ( DataWidth ),
+    .IdWidth   ( 1         )
+  ) tb_c_req_t;
+
+  typedef acc_test::c_rsp_t # (
+    .DataWidth ( DataWidth ),
+    .IdWidth   ( 1         )
+  ) tb_c_rsp_t;
+
+  typedef acc_test::x_req_t #(
+    .DataWidth ( DataWidth )
+  ) tb_x_req_t;
+
+  typedef acc_test::x_rsp_t #(
+    .DataWidth (DataWidth)
+  ) tb_x_rsp_t;
+
+  typedef acc_test::prd_req_t tb_prd_req_t;
+  typedef acc_test::prd_rsp_t tb_prd_rsp_t;
+
+  // From / to core
+  ACC_X_BUS #(
+    .DataWidth ( DataWidth )
+  ) x_master ();
+
+  ACC_X_BUS_DV #(
+    .DataWidth ( DataWidth )
+  ) x_master_dv ( clk );
+
+  // From / to interconnect
+  ACC_C_BUS #(
+    .AddrWidth ( AddrWidth ),
+    .DataWidth ( DataWidth ),
+    .IdWidth   ( 1         )
+  ) c_slave ();
+
+  ACC_C_BUS_DV #(
+    .AddrWidth ( AddrWidth ),
+    .DataWidth ( DataWidth ),
+    .IdWidth   ( 1         )
+  ) c_slave_dv ( clk );
+
+  // From / to predecoders
+  ACC_PRD_BUS prd_master [NumRspTot] ();
+
+  ACC_PRD_BUS_DV prd_master_dv [NumRspTot] ( clk );
+
+  // Interface assignments
+  `ACC_C_ASSIGN(c_slave_dv, c_slave)
+
+  `ACC_X_ASSIGN(x_master, x_master_dv)
+
+  for (genvar i=0; i<NumRspTot; i++) begin : gen_predecoder_intf_assign
+    `ACC_PRD_ASSIGN(prd_master_dv[i], prd_master[i])
+  end
+
+  // --------
+  // Monitors
+  // --------
+  typedef acc_test::acc_c_slv_monitor #(
+    // Acc bus interface paramaters;
+    .DataWidth ( DataWidth ),
+    .AddrWidth ( AddrWidth ),
+    .IdWidth   ( 1         ),
+    // Stimuli application and test time
+    .TA ( ApplTime ),
+    .TT ( TestTime )
+  ) acc_c_slv_monitor_t;
+
+  typedef acc_test::acc_x_monitor #(
+    .DataWidth ( DataWidth ),
+    .TA        ( ApplTime  ),
+    .TT        ( TestTime  )
+  ) acc_x_monitor_t;
+
+  typedef acc_test::acc_prd_monitor #(
+    .TA ( ApplTime ),
+    .TT ( TestTime )
+  ) acc_prd_monitor_t;
+
+
+  acc_c_slv_monitor_t acc_c_slv_monitor = new(c_slave_dv);
+  initial begin
+    @(posedge rst_n);
+    acc_c_slv_monitor.monitor();
+  end
+
+  acc_x_monitor_t acc_x_mst_monitor = new(x_master_dv);
+  initial begin
+    @(posedge rst_n);
+    acc_x_mst_monitor.monitor();
+  end
+
+  acc_prd_monitor_t acc_prd_monitor[NumRspTot];
+  for (genvar i=0; i<NumRspTot; i++) begin : gen_predecoder_monitor
+    initial begin
+      acc_prd_monitor[i] = new(prd_master_dv[i]);
+      @(posedge rst_n);
+      acc_prd_monitor[i].monitor();
+    end
+  end
+
+  // -------
+  // Drivers
+  // -------
+
+  typedef acc_test::rand_x_master#(
+    .DataWidth ( DataWidth ),
+    .TA        ( ApplTime  ),
+    .TT        ( TestTime  )
+  ) rand_x_master_t;
+
+  typedef acc_test::rand_c_slave#(
+    .AddrWidth ( AddrWidth ),
+    .DataWidth ( DataWidth ),
+    .IdWidth   ( 1         ),
+    .TA        ( ApplTime  ),
+    .TT        ( TestTime  )
+  ) rand_c_slave_t;
+
+  typedef acc_test::rand_prd_slave_collective #(
+    .NumRspTot ( NumRspTot ),
+    .TA        ( ApplTime  ),
+    .TT        ( TestTime  )
+  ) rand_prd_slv_coll_t;
+
+  rand_x_master_t rand_x_master = new(x_master_dv);
+  initial begin
+    rand_x_master.reset();
+    @(posedge rst_n);
+    rand_x_master.run(NrRandomTransactions);
+  end
+
+  rand_prd_slv_coll_t rand_prd_slv_coll = new(prd_master_dv);
+  initial begin
+    rand_prd_slv_coll.reset();
+    @(posedge rst_n);
+    rand_prd_slv_coll.run();
+  end
+
+  rand_c_slave_t rand_c_slave = new(c_slave_dv);
+  initial begin
+    rand_c_slave.reset();
+    @(posedge rst_n);
+    rand_c_slave.run();
+  end
+
+  // Request generation checker
+  let check_req(x_req, prd_rsp, c_req) =
+    acc_test::adp_check_req #(
+      .acc_c_req_t   ( tb_c_req_t   ),
+      .acc_x_req_t   ( tb_x_req_t   ),
+      .acc_prd_rsp_t ( tb_prd_rsp_t )
+    )::do_check(x_req, prd_rsp, c_req);
+
+  // Response checker
+  // TODO: MARK0
+  let check_rsp(c_rsp, x_rsp) =
+    acc_test::compare_c_x_rsp #(
+      .c_rsp_t(tb_c_rsp_t),
+      //.x_rsp_t(tb_x_rsp_t)
+      .x_rsp_t(acc_test::x_rsp_t#(32))
+    )::do_compare(c_rsp, x_rsp);
+
+  // Scoreboard
+  // Request Path
+  // ------------
+  // For each request entering the interconnect (acc_slave_monitor), check
+  //  - Address corresponds to accepting predecoder
+  //  - Operands generated from adapter_master using mux signals from
+  //  predecoder
+  //  - instr_data properly forwarded
+  // For each rejected request, check that no predecoder has accepted it
+  //
+  // Response Path
+  // -------------
+  // Responses are just randomly generated and forwarded from C-Slave to
+  // X-Master.
+  // Check that they reach their target and remain the same.
+  initial begin
+    automatic int nr_requests          = 0;
+    automatic int nr_requests_rejected = 0;
+    automatic int nr_responses         = 0;
+    @(posedge rst_n);
+    fork
+      // Request Path
+      // ------------
+      // Check accepted requests
+      forever begin
+        automatic tb_x_req_t x_req;
+        automatic tb_c_req_t c_req;
+        automatic tb_prd_rsp_t prd_rsp;
+        automatic tb_prd_req_t prd_req;
+        automatic int prd_id, i;
+        // Wait for a request at the interconnect output
+        acc_c_slv_monitor.req_mbx[0].get(c_req);
+
+        // get predecoder ID
+        // level-specific address
+        prd_id = c_req.addr[AccAddrWidth-1:0];
+        i = 0;
+        while ( i != c_req.addr[AddrWidth-1:AccAddrWidth]) begin
+          // for each level add number of attached Responders
+          prd_id += NumRsp[i];
+          i++;
+        end
+        // get accepting predecoder response and request structures and
+        // corresponding adapter request.
+        assert(acc_prd_monitor[prd_id].req_mbx.try_get(prd_req)) else
+          $error("C slave request without corresponding predecoder request");
+        assert(acc_prd_monitor[prd_id].rsp_mbx.try_get(prd_rsp)) else
+          $error("C slave request without corresponding predecoder response");
+        assert(acc_x_mst_monitor.req_mbx.try_get(x_req)) else
+          $error("C slave request without corresponding X master request");
+        assert((prd_req.instr_data ^ (x_req.instr_data ^ c_req.instr_data)) == '0) else
+          $error("C slave request does not match predecoder or X request");
+        assert(check_req(x_req, prd_rsp, c_req)) else
+          $error("C slave request construction fault");
+        nr_requests++;
+      end
+
+      // check rejected requests
+      forever begin
+        automatic tb_x_req_t x_req;
+        // Wait for rejected request
+        acc_x_mst_monitor.req_mbx_rejected.get(x_req);
+        // Check if any predecoder wanted to accept this request.
+        for (int i = 0; i< NumRspTot; i++) begin
+          automatic tb_prd_req_t prd_req;
+          if (acc_prd_monitor[i].req_mbx.try_peek(prd_req)) begin
+            // Instruction data is `randc`
+            // no repetitions in 2**32 samples
+            assert (prd_req.instr_data != x_req.instr_data) else
+              $error("Rejected X master request was accepted by predecoder");
+          end
+        end
+        nr_requests_rejected++;
+      end
+
+      // Response path
+      // -------------
+      forever begin
+
+        // automatic tb_x_rsp_t x_rsp;
+        automatic  acc_test::x_rsp_t#(32) x_rsp;
+        // Seems to be necessary here to explicitly refer to the class from
+        // acc_test.
+        // TODO: Why doesn't it work with typedef?! Same problem: MARK0
+        // questasim raises fatal error:
+        // # ** Error: (vsim-7065) Illegal assignment to class work.acc_test::
+        // x_rsp_t #(32) from  class work.acc_test::x_rsp_t #(32)
+        automatic tb_c_rsp_t c_rsp;
+        // Wait for response at X master interface
+        acc_x_mst_monitor.rsp_mbx.get(x_rsp);
+        // ASSERT: There X response == C response
+        assert(acc_c_slv_monitor.rsp_mbx[0].try_get(c_rsp)) else
+          $error("X Master response without corresponding C slave response");
+        assert(check_rsp(c_rsp, x_rsp)) else
+          $error("X Master response does not match C slave response");
+
+        nr_responses++;
+        if (nr_responses == NrRandomTransactions - nr_requests_rejected) $finish;
+      end
+
+    join_none
+  end
+
+  final begin
+    // Request path:
+    for (int i=0; i<NumRspTot; i++) begin
+      assert(acc_prd_monitor[i].req_mbx.num() == 0);
+    end
+    assert(acc_x_mst_monitor.req_mbx.num() == 0);
+    assert(acc_x_mst_monitor.req_mbx_rejected.num() == 0);
+    assert(acc_c_slv_monitor.req_mbx[0].num() == 0);
+    // Response path:
+    assert(acc_c_slv_monitor.rsp_mbx[0].num() == 0);
+    assert(acc_x_mst_monitor.rsp_mbx.num() == 0);
+    $display("Checked for non-empty mailboxes");
+  end
+
+  // DUT instantiation
+  acc_adapter_intf #(
+    .DataWidth ( DataWidth ),
+    .NumHier   ( NumHier   ),
+    .NumRsp    ( NumRsp    )
+  ) dut (
+    .clk_i       ( clk        ),
+    .rst_ni      ( rst_n      ),
+    .acc_x_mst   ( x_master   ),
+    .acc_c_slv   ( c_slave    ),
+    .acc_prd_mst ( prd_master )
+  );
+
+endmodule

--- a/test/acc_interconnect_tb.sv
+++ b/test/acc_interconnect_tb.sv
@@ -15,10 +15,10 @@ module acc_interconnect_tb  #(
   parameter int NumRsp[NumHier] = '{3,5,9},
   parameter int HierLevel       = 1, // 0, .., NumHier-1
   parameter int DataWidth       = 32,
-  parameter bit RegisterReq     = 0,
-  parameter bit RegisterRsp     = 0,
+  parameter bit RegisterReq     = 1,
+  parameter bit RegisterRsp     = 1,
   // TB params
-  parameter int unsigned NrRandomTransactions = 10
+  parameter int unsigned NrRandomTransactions = 1000
 );
 
   // dependent parameters
@@ -26,29 +26,24 @@ module acc_interconnect_tb  #(
   localparam int unsigned AccAddrWidth  = cf_math_pkg::idx_width(MaxNumRsp);
   localparam int unsigned HierAddrWidth = cf_math_pkg::idx_width(NumHier);
   localparam int unsigned AddrWidth     = AccAddrWidth + HierAddrWidth;
-  localparam int unsigned ExtIdWidth    = 1+ cf_math_pkg::idx_width(NumReq);
 
 
-  typedef acc_test::c_req_t # (
+  typedef acc_test::c_req_t #(
     .AddrWidth ( AddrWidth ),
-    .DataWidth ( DataWidth ),
-    .IdWidth   ( 1         )
+    .DataWidth ( DataWidth )
   ) tb_mst_c_req_t;
 
-  typedef acc_test::c_rsp_t # (
-    .DataWidth ( DataWidth ),
-    .IdWidth   ( 1         )
+  typedef acc_test::c_rsp_t #(
+    .DataWidth ( DataWidth )
   ) tb_mst_c_rsp_t;
 
-  typedef acc_test::c_req_t # (
+  typedef acc_test::c_req_t #(
     .AddrWidth ( AddrWidth ),
-    .DataWidth ( DataWidth ),
-    .IdWidth   ( ExtIdWidth  )
+    .DataWidth ( DataWidth )
   ) tb_slv_c_req_t;
 
-  typedef acc_test::c_rsp_t # (
-    .DataWidth    ( DataWidth  ),
-    .IdWidth      ( ExtIdWidth )
+  typedef acc_test::c_rsp_t #(
+    .DataWidth ( DataWidth )
   ) tb_slv_c_rsp_t;
 
   // Timing params
@@ -60,49 +55,49 @@ module acc_interconnect_tb  #(
 
   ACC_C_BUS #(
     .AddrWidth ( AddrWidth ),
-    .DataWidth ( DataWidth ),
-    .IdWidth   ( 1         )
-  ) master [NumReq] ();
+    .DataWidth ( DataWidth )
+  ) master[NumReq] ();
 
   ACC_C_BUS_DV #(
     .AddrWidth ( AddrWidth ),
-    .DataWidth ( DataWidth ),
-    .IdWidth   ( 1         )
-  ) master_dv [NumReq] (clk);
+    .DataWidth ( DataWidth )
+  ) master_dv[NumReq] (
+    clk
+  );
 
   ACC_C_BUS #(
     .AddrWidth ( AddrWidth ),
-    .DataWidth ( DataWidth ),
-    .IdWidth   ( 1         )
-  ) slave_next [NumReq] ();
+    .DataWidth ( DataWidth )
+  ) slave_next[NumReq] ();
 
   ACC_C_BUS_DV #(
     .AddrWidth ( AddrWidth ),
-    .DataWidth ( DataWidth ),
-    .IdWidth   ( 1         )
-  ) slave_next_dv [NumReq] (clk);
+    .DataWidth ( DataWidth )
+  ) slave_next_dv[NumReq] (
+    clk
+  );
 
   ACC_C_BUS #(
     .AddrWidth ( AddrWidth  ),
-    .DataWidth ( DataWidth  ),
-    .IdWidth   ( ExtIdWidth )
-  ) slave [NumRsp[HierLevel]] ();
+    .DataWidth ( DataWidth  )
+  ) slave[NumRsp[HierLevel]] ();
 
   ACC_C_BUS_DV #(
     .AddrWidth ( AddrWidth  ),
-    .DataWidth ( DataWidth  ),
-    .IdWidth   ( ExtIdWidth )
-  ) slave_dv [NumRsp[HierLevel]] (clk);
+    .DataWidth ( DataWidth  )
+  ) slave_dv[NumRsp[HierLevel]](
+    clk
+  );
 
-  for (genvar i=0; i<NumReq; i++) begin : gen_mst_if_assignement
+  for (genvar i = 0; i < NumReq; i++) begin : gen_mst_if_assignement
     `ACC_C_ASSIGN(master[i], master_dv[i])
   end
 
-  for (genvar i=0; i<NumReq; i++) begin : gen_mst_next_if_assignement
+  for (genvar i = 0; i < NumReq; i++) begin : gen_mst_next_if_assignement
     `ACC_C_ASSIGN(slave_next_dv[i], slave_next[i])
   end
 
-  for (genvar i=0; i<NumRsp[HierLevel]; i++) begin : gen_slv_if_assignement
+  for (genvar i = 0; i < NumRsp[HierLevel]; i++) begin : gen_slv_if_assignement
     `ACC_C_ASSIGN(slave_dv[i], slave[i])
   end
 
@@ -112,13 +107,13 @@ module acc_interconnect_tb  #(
   initial begin
     rst_n = 0;
     repeat (3) begin
-      #(ClkPeriod/2) clk = 0;
-      #(ClkPeriod/2) clk = 1;
+      #(ClkPeriod / 2) clk = 0;
+      #(ClkPeriod / 2) clk = 1;
     end
     rst_n = 1;
     forever begin
-      #(ClkPeriod/2) clk = 0;
-      #(ClkPeriod/2) clk = 1;
+      #(ClkPeriod / 2) clk = 0;
+      #(ClkPeriod / 2) clk = 1;
     end
   end
 
@@ -126,39 +121,24 @@ module acc_interconnect_tb  #(
   // Monitor
   // -------
   typedef acc_test::acc_c_slv_monitor #(
-    // Acc bus interface paramaters;
-    .DataWidth ( DataWidth  ),
-    .AddrWidth ( AddrWidth  ),
-    .IdWidth   ( ExtIdWidth ),
-    // Stimuli application and test time
-    .TA ( ApplTime ),
-    .TT ( TestTime )
+    .DataWidth ( DataWidth ),
+    .AddrWidth ( AddrWidth ),
+    .NumReq    ( NumReq    ),
+    .TA        ( ApplTime  ),
+    .TT        ( TestTime  )
   ) acc_c_slv_monitor_t;
 
-  typedef acc_test::acc_c_slv_monitor #(
-    // Acc bus interface paramaters;
-    .DataWidth ( DataWidth  ),
-    .AddrWidth ( AddrWidth  ),
-    .IdWidth   ( 1          ),
-    // Stimuli application and test time
-    .TA ( ApplTime ),
-    .TT ( TestTime )
-  ) acc_c_fwd_slv_monitor_t;
-
   typedef acc_test::acc_c_mst_monitor #(
-    // Acc bus interface paramaters;
     .DataWidth    ( DataWidth    ),
     .AddrWidth    ( AddrWidth    ),
     .AccAddrWidth ( AccAddrWidth ),
-    .IdWidth      ( 1            ),
     .HierLevel    ( HierLevel    ),
-    // Stimuli application and test time
-    .TA ( ApplTime ),
-    .TT ( TestTime )
+    .TA           ( ApplTime     ),
+    .TT           ( TestTime     )
   ) acc_c_mst_monitor_t;
 
-  acc_c_mst_monitor_t acc_c_mst_monitor [NumReq];
-  for (genvar i=0; i<NumReq; i++) begin : gen_mst_mon
+  acc_c_mst_monitor_t acc_c_mst_monitor[NumReq];
+  for (genvar i = 0; i < NumReq; i++) begin : gen_mst_mon
     initial begin
       acc_c_mst_monitor[i] = new(master_dv[i]);
       @(posedge rst_n);
@@ -166,8 +146,8 @@ module acc_interconnect_tb  #(
     end
   end
 
-  acc_c_slv_monitor_t acc_c_slv_monitor [NumRsp[HierLevel]];
-  for (genvar i=0; i<NumRsp[HierLevel]; i++) begin : gen_slv_mon
+  acc_c_slv_monitor_t acc_c_slv_monitor[NumRsp[HierLevel]];
+  for (genvar i = 0; i < NumRsp[HierLevel]; i++) begin : gen_slv_mon
     initial begin
       acc_c_slv_monitor[i] = new(slave_dv[i]);
       @(posedge rst_n);
@@ -175,8 +155,8 @@ module acc_interconnect_tb  #(
     end
   end
 
-  acc_c_fwd_slv_monitor_t acc_c_fwd_slv_monitor [NumReq];
-  for (genvar i=0; i<NumReq; i++) begin : gen_fwd_slv_mon
+  acc_c_slv_monitor_t acc_c_fwd_slv_monitor[NumReq];
+  for (genvar i = 0; i < NumReq; i++) begin : gen_fwd_slv_mon
     initial begin
       acc_c_fwd_slv_monitor[i] = new(slave_next_dv[i]);
       @(posedge rst_n);
@@ -187,132 +167,102 @@ module acc_interconnect_tb  #(
   // ------
   // Driver
   // ------
-  // Slaves on same interconnect HierLevel
   typedef acc_test::rand_c_slave #(
-    // Acc bus interface paramaters;
-    .DataWidth ( DataWidth  ),
-    .AddrWidth ( AddrWidth  ),
-    .IdWidth   ( ExtIdWidth ),
-    // Stimuli application and test time
-    .TA ( ApplTime ),
-    .TT ( TestTime )
+    .DataWidth ( DataWidth ),
+    .AddrWidth ( AddrWidth ),
+    .NumReq    ( NumReq    ),
+    .TA        ( ApplTime  ),
+    .TT        ( TestTime  )
   ) rand_c_slave_t;
 
-  rand_c_slave_t rand_c_slave [NumRsp[HierLevel]];
-  for (genvar i=0; i<NumRsp[HierLevel]; i++) begin : gen_slv_driver
+  // Slaves connected to this interconnect level
+  rand_c_slave_t rand_c_slave[NumRsp[HierLevel]];
+  for (genvar i = 0; i < NumRsp[HierLevel]; i++) begin : gen_slv_driver
     initial begin
-      rand_c_slave[i] = new (slave_dv[i]);
+      rand_c_slave[i] = new(slave_dv[i]);
       rand_c_slave[i].reset();
       @(posedge rst_n);
       rand_c_slave[i].run();
     end
   end
 
-  // Slaves on higher interconnect level.
-  typedef acc_test::rand_c_slave #(
-    // Acc bus interface paramaters;
-    .DataWidth ( DataWidth ),
-    .AddrWidth ( AddrWidth ),
-    .IdWidth   ( 1         ),
-    // Stimuli application and test time
-    .TA ( ApplTime ),
-    .TT ( TestTime )
-  ) rand_c_fwd_slave_t;
-
-
-  // Requests / responses originating from higher interconnect levels
-  // have already been sorted to the appropriate requester port.
-  rand_c_fwd_slave_t rand_c_fwd_slave[NumReq];
-  for (genvar i=0; i<NumReq; i++) begin : gen_c_slv_fwd_driver
+  // Slaves conected to higher interconnect levels
+  rand_c_slave_t rand_c_fwd_slave[NumReq];
+  for (genvar i = 0; i < NumReq; i++) begin : gen_c_slv_fwd_driver
     initial begin
-      rand_c_fwd_slave[i] = new (slave_next_dv[i]);
+      rand_c_fwd_slave[i] = new(slave_next_dv[i]);
       rand_c_fwd_slave[i].reset();
       @(posedge rst_n);
       rand_c_fwd_slave[i].run();
     end
   end
 
-
   typedef acc_test::rand_c_master #(
-    // Acc bus interface paramaters;
     .DataWidth    ( DataWidth    ),
     .AccAddrWidth ( AccAddrWidth ),
     .AddrWidth    ( AddrWidth    ),
-    .IdWidth      ( 1            ),
     .NumRsp       ( NumRsp       ),
     .NumHier      ( NumHier      ),
     .HierLevel    ( HierLevel    ),
-    // Stimuli application and test time
-    .TA ( ApplTime ),
-    .TT ( TestTime )
-  ) acc_rand_master_t;
+    .TA           ( ApplTime     ),
+    .TT           ( TestTime     )
+  ) rand_c_master_t;
 
-  acc_rand_master_t rand_c_master [NumReq];
+  rand_c_master_t rand_c_master[NumReq];
 
   for (genvar i = 0; i < NumReq; i++) begin : gen_c_master
     initial begin
-      rand_c_master[i] = new (master_dv[i]);
+      automatic acc_test::rand_hart_id hid = new;
+      assert(hid.randomize());
+      rand_c_master[i] = new(master_dv[i], hid.hart_id);
       rand_c_master[i].reset();
       @(posedge rst_n);
       rand_c_master[i].run(NrRandomTransactions);
     end
   end
 
-  // Compare reqs of different parameterizations
-  let mstslv_c_reqcompare(req_mst, req_slv) =
-    acc_test::compare_c_req#(
-      .mst_c_req_t ( tb_mst_c_req_t ),
-      .slv_c_req_t ( tb_slv_c_req_t )
-    )::do_compare(req_mst, req_slv);
-
-  // Compare rsps of different parameterizations
-  let mstslv_c_rspcompare(rsp_mst, rsp_slv) =
-    acc_test::compare_c_rsp#(
-      .mst_c_rsp_t ( tb_mst_c_rsp_t ),
-      .slv_c_rsp_t ( tb_slv_c_rsp_t )
-    )::do_compare(rsp_mst, rsp_slv);
-
   // ----------
   // Scoreboard
   // ----------
-  // For each master check that each request sent has been received by
-  // the correct slave.
-  // For each slave, check that each response sent has been received by
-  // the correct master.
-  // Stop when all responses have been received.
   //
-  // TODO: Add possibility for no-response requests.
-  //       For check if interconnect is correct, this is fine.
-
   // Request Path
   // ------------
+  // Try to map each request observed at the output to a request generated at
+  // an input port.
   initial begin
     automatic int nr_requests = 0;
     @(posedge rst_n);
-    for (int kk=0; kk<NumReq; kk++) begin // masters k
-      automatic int k=kk;
+    for (int kk = 0; kk < NumReq; kk++) begin  // masters k
+      automatic int k = kk;
       fork
         // Check requests to same-level slaves
-        for (int ii=0; ii<NumRsp[HierLevel]; ii++) begin // slaves i
+        for (int ii = 0; ii < NumRsp[HierLevel]; ii++) begin  // slaves i
           fork
-            automatic int i=ii;
+            automatic int i = ii;
             forever begin : check_req_path
               automatic tb_mst_c_req_t req_mst;
               automatic tb_slv_c_req_t req_slv;
               automatic tb_slv_c_req_t req_slv_all[NumReq];
-              // Master k has sent request to slave i.
-              // Check that slave i has received.
-              acc_c_slv_monitor[i].req_mbx[k<<1].get(req_slv);
-              acc_c_mst_monitor[k].req_mbx[i].get(req_mst);
-              assert(mstslv_c_reqcompare(req_mst, req_slv)) else
+              automatic int sender_id = -1;
+              acc_c_slv_monitor[i].req_mbx_cnt.get_direct(req_slv, k);
+              for (int l = 0; l < NumReq; l++) begin
+                if (rand_c_master[l].drv.hart_id == req_slv.hart_id) begin
+                  sender_id = l;
+                  acc_c_mst_monitor[l].req_mbx[i].get(req_mst);
+                end
+              end
+              assert (sender_id >= 0) else
+                $error("Request Routing Error: C Slave %0d", i,
+                    "Could not determine origin of C request");
+              assert(req_mst.do_compare(req_slv)) else
                 $error("Request Mismatch: C master %0d to C slave %0d", k, i);
               // check that request was intended for slave i
               assert(req_mst.addr[AccAddrWidth-1:0] == i) else
-                $error("Request Routing Error: C Master %0d", k);
+                $error("Request Routing Error: C Master %0d", sender_id);
               nr_requests++;
-            end // -- forever
+            end  // -- forever
           join_none
-        end // -- for (int i=0; i<NumRsp[HierLevel]; i++)
+        end  // -- for (int i=0; i<NumRsp[HierLevel]; i++)
 
         // Check forwarded requests
         fork
@@ -321,24 +271,24 @@ module acc_interconnect_tb  #(
             automatic tb_mst_c_req_t req_slv_fwd;
             // Master k has sent interconnect forward port k
             // Check that slave k has received.
-            acc_c_fwd_slv_monitor[k].req_mbx[0].get(req_slv_fwd);
+            acc_c_fwd_slv_monitor[k].req_mbx_cnt.get_direct(req_slv_fwd, 0);
             acc_c_mst_monitor[k].req_mbx_fwd.get(req_mst);
             assert(req_mst.do_compare(req_slv_fwd)) else
               $error("Forwarded Request Mismatch: C Master %0d", k);
             nr_requests++;
-          end // -- forever
+          end  // -- forever
         join_none
       join_none
     end
   end
 
-  // For each response received by a master, check that request has been issued.
+  // Map each reponse observed at the output to a response generated at the input port.
   initial begin
     automatic int unsigned nr_responses = 0;
     @(posedge rst_n);
-    for (int jj=0; jj<NumReq; jj++) begin
+    for (int jj = 0; jj < NumReq; jj++) begin
       fork
-        automatic int j=jj;
+        automatic int j = jj;
         forever begin
           automatic tb_mst_c_rsp_t rsp_mst;
           automatic tb_mst_c_rsp_t rsp_slv_fwd;
@@ -346,24 +296,22 @@ module acc_interconnect_tb  #(
           acc_c_mst_monitor[j].rsp_mbx.get(rsp_mst);
           nr_responses++;
           // Check this interconnect level
-          for (int l=0; l<NumRsp[HierLevel]; l++) begin
-            //$display("Slave monitor %0x, rsp_mbx[%0x], mbox!=0: ",l, j<<1, acc_c_slv_monitor[l].rsp_mbx[j<<1].num() != 0);
-            if (acc_c_slv_monitor[l].rsp_mbx[j<<1].num() != 0) begin
+          for (int l = 0; l < NumRsp[HierLevel]; l++) begin
+            if (acc_c_slv_monitor[l].rsp_mbx_cnt.num(rsp_mst.hart_id) != 0) begin
               automatic tb_slv_c_rsp_t rsp_slv;
-              acc_c_slv_monitor[l].rsp_mbx[j<<1].peek(rsp_slv);
-              if (mstslv_c_rspcompare(rsp_mst, rsp_slv)) begin
-                acc_c_slv_monitor[l].rsp_mbx[j<<1].get(rsp_slv);
+              acc_c_slv_monitor[l].rsp_mbx_cnt.peek(rsp_slv, rsp_mst.hart_id);
+              if (rsp_mst.do_compare(rsp_slv)) begin
+                acc_c_slv_monitor[l].rsp_mbx_cnt.get(rsp_slv, rsp_mst.hart_id);
                 rsp_sender_found |= 1;
                 break;
               end
             end
           end
-          // Check upper interconnect level (can only have originated
-          // from corresponding forward connection)
-          if (acc_c_fwd_slv_monitor[j].rsp_mbx[0].num() !=0 ) begin
-            acc_c_fwd_slv_monitor[j].rsp_mbx[0].peek(rsp_slv_fwd);
+          // Check forwarded responses from upper interconnect levels.
+          if (acc_c_fwd_slv_monitor[j].rsp_mbx_cnt.num(rsp_mst.hart_id) != 0) begin
+            acc_c_fwd_slv_monitor[j].rsp_mbx_cnt.peek(rsp_slv_fwd, rsp_mst.hart_id);
             if (rsp_mst.do_compare(rsp_slv_fwd)) begin
-              acc_c_fwd_slv_monitor[j].rsp_mbx[0].get(rsp_slv_fwd);
+              acc_c_fwd_slv_monitor[j].rsp_mbx_cnt.get(rsp_slv_fwd, rsp_mst.hart_id);
               rsp_sender_found |= 1;
             end
           end
@@ -376,16 +324,17 @@ module acc_interconnect_tb  #(
     end
   end
 
+
   final begin
-    for (int i=0; i<NumReq; i++) begin
+    for (int i = 0; i < NumReq; i++) begin
       assert(acc_c_mst_monitor[i].rsp_mbx.num() == 0);
-      assert(acc_c_mst_monitor[i].req_mbx_fwd.num() ==0);
-      assert(acc_c_fwd_slv_monitor[i].req_mbx[0].num()==0);
-      assert(acc_c_fwd_slv_monitor[i].rsp_mbx[0].num()==0);
-      for (int j=0; j<NumRsp[HierLevel]; j++) begin
+      assert(acc_c_mst_monitor[i].req_mbx_fwd.num() == 0);
+      assert(acc_c_fwd_slv_monitor[i].req_mbx_cnt.empty());
+      assert(acc_c_fwd_slv_monitor[i].rsp_mbx_cnt.empty());
+      for (int j = 0; j < NumRsp[HierLevel]; j++) begin
         assert(acc_c_mst_monitor[i].req_mbx[j].num() == 0);
-        assert(acc_c_slv_monitor[j].req_mbx[i].num() == 0);
-        assert(acc_c_slv_monitor[j].rsp_mbx[i].num() == 0);
+        assert(acc_c_slv_monitor[j].req_mbx_cnt.empty());
+        assert(acc_c_slv_monitor[j].rsp_mbx_cnt.empty());
       end
     end
     $display("Checked for non-empty mailboxes.");

--- a/test/acc_interconnect_tb.sv
+++ b/test/acc_interconnect_tb.sv
@@ -1,0 +1,411 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Noam Gallmann <gnoam@live.com>
+//
+// Simulates one hierarchy level of the accelerator interconnect.
+
+`include "acc_interface/assign.svh"
+`include "acc_interface/typedef.svh"
+
+module acc_interconnect_tb  #(
+  parameter int NumHier         = 3,
+  parameter int NumReq          = 8,
+  parameter int NumRsp[NumHier] = '{3,5,9},
+  parameter int HierLevel       = 1, // 0, .., NumHier-1
+  parameter int DataWidth       = 32,
+  parameter bit RegisterReq     = 0,
+  parameter bit RegisterRsp     = 0,
+  // TB params
+  parameter int unsigned NrRandomTransactions = 10
+);
+
+  // dependent parameters
+  localparam int unsigned MaxNumRsp     = acc_pkg::maxn(NumRsp, NumHier);
+  localparam int unsigned AccAddrWidth  = cf_math_pkg::idx_width(MaxNumRsp);
+  localparam int unsigned HierAddrWidth = cf_math_pkg::idx_width(NumHier);
+  localparam int unsigned AddrWidth     = AccAddrWidth + HierAddrWidth;
+  localparam int unsigned ExtIdWidth    = 1+ cf_math_pkg::idx_width(NumReq);
+
+
+  typedef acc_test::c_req_t # (
+    .AddrWidth ( AddrWidth ),
+    .DataWidth ( DataWidth ),
+    .IdWidth   ( 1         )
+  ) tb_mst_c_req_t;
+
+  typedef acc_test::c_rsp_t # (
+    .DataWidth ( DataWidth ),
+    .IdWidth   ( 1         )
+  ) tb_mst_c_rsp_t;
+
+  typedef acc_test::c_req_t # (
+    .AddrWidth ( AddrWidth ),
+    .DataWidth ( DataWidth ),
+    .IdWidth   ( ExtIdWidth  )
+  ) tb_slv_c_req_t;
+
+  typedef acc_test::c_rsp_t # (
+    .DataWidth    ( DataWidth  ),
+    .IdWidth      ( ExtIdWidth )
+  ) tb_slv_c_rsp_t;
+
+  // Timing params
+  localparam time ClkPeriod = 10ns;
+  localparam time ApplTime =  2ns;
+  localparam time TestTime =  8ns;
+
+  logic clk, rst_n;
+
+  ACC_C_BUS #(
+    .AddrWidth ( AddrWidth ),
+    .DataWidth ( DataWidth ),
+    .IdWidth   ( 1         )
+  ) master [NumReq] ();
+
+  ACC_C_BUS_DV #(
+    .AddrWidth ( AddrWidth ),
+    .DataWidth ( DataWidth ),
+    .IdWidth   ( 1         )
+  ) master_dv [NumReq] (clk);
+
+  ACC_C_BUS #(
+    .AddrWidth ( AddrWidth ),
+    .DataWidth ( DataWidth ),
+    .IdWidth   ( 1         )
+  ) slave_next [NumReq] ();
+
+  ACC_C_BUS_DV #(
+    .AddrWidth ( AddrWidth ),
+    .DataWidth ( DataWidth ),
+    .IdWidth   ( 1         )
+  ) slave_next_dv [NumReq] (clk);
+
+  ACC_C_BUS #(
+    .AddrWidth ( AddrWidth  ),
+    .DataWidth ( DataWidth  ),
+    .IdWidth   ( ExtIdWidth )
+  ) slave [NumRsp[HierLevel]] ();
+
+  ACC_C_BUS_DV #(
+    .AddrWidth ( AddrWidth  ),
+    .DataWidth ( DataWidth  ),
+    .IdWidth   ( ExtIdWidth )
+  ) slave_dv [NumRsp[HierLevel]] (clk);
+
+  for (genvar i=0; i<NumReq; i++) begin : gen_mst_if_assignement
+    `ACC_C_ASSIGN(master[i], master_dv[i])
+  end
+
+  for (genvar i=0; i<NumReq; i++) begin : gen_mst_next_if_assignement
+    `ACC_C_ASSIGN(slave_next_dv[i], slave_next[i])
+  end
+
+  for (genvar i=0; i<NumRsp[HierLevel]; i++) begin : gen_slv_if_assignement
+    `ACC_C_ASSIGN(slave_dv[i], slave[i])
+  end
+
+  // ----------------
+  // Clock generation
+  // ----------------
+  initial begin
+    rst_n = 0;
+    repeat (3) begin
+      #(ClkPeriod/2) clk = 0;
+      #(ClkPeriod/2) clk = 1;
+    end
+    rst_n = 1;
+    forever begin
+      #(ClkPeriod/2) clk = 0;
+      #(ClkPeriod/2) clk = 1;
+    end
+  end
+
+  // -------
+  // Monitor
+  // -------
+  typedef acc_test::acc_c_slv_monitor #(
+    // Acc bus interface paramaters;
+    .DataWidth ( DataWidth  ),
+    .AddrWidth ( AddrWidth  ),
+    .IdWidth   ( ExtIdWidth ),
+    // Stimuli application and test time
+    .TA ( ApplTime ),
+    .TT ( TestTime )
+  ) acc_c_slv_monitor_t;
+
+  typedef acc_test::acc_c_slv_monitor #(
+    // Acc bus interface paramaters;
+    .DataWidth ( DataWidth  ),
+    .AddrWidth ( AddrWidth  ),
+    .IdWidth   ( 1          ),
+    // Stimuli application and test time
+    .TA ( ApplTime ),
+    .TT ( TestTime )
+  ) acc_c_fwd_slv_monitor_t;
+
+  typedef acc_test::acc_c_mst_monitor #(
+    // Acc bus interface paramaters;
+    .DataWidth    ( DataWidth    ),
+    .AddrWidth    ( AddrWidth    ),
+    .AccAddrWidth ( AccAddrWidth ),
+    .IdWidth      ( 1            ),
+    .HierLevel    ( HierLevel    ),
+    // Stimuli application and test time
+    .TA ( ApplTime ),
+    .TT ( TestTime )
+  ) acc_c_mst_monitor_t;
+
+  acc_c_mst_monitor_t acc_c_mst_monitor [NumReq];
+  for (genvar i=0; i<NumReq; i++) begin : gen_mst_mon
+    initial begin
+      acc_c_mst_monitor[i] = new(master_dv[i]);
+      @(posedge rst_n);
+      acc_c_mst_monitor[i].monitor();
+    end
+  end
+
+  acc_c_slv_monitor_t acc_c_slv_monitor [NumRsp[HierLevel]];
+  for (genvar i=0; i<NumRsp[HierLevel]; i++) begin : gen_slv_mon
+    initial begin
+      acc_c_slv_monitor[i] = new(slave_dv[i]);
+      @(posedge rst_n);
+      acc_c_slv_monitor[i].monitor();
+    end
+  end
+
+  acc_c_fwd_slv_monitor_t acc_c_fwd_slv_monitor [NumReq];
+  for (genvar i=0; i<NumReq; i++) begin : gen_fwd_slv_mon
+    initial begin
+      acc_c_fwd_slv_monitor[i] = new(slave_next_dv[i]);
+      @(posedge rst_n);
+      acc_c_fwd_slv_monitor[i].monitor();
+    end
+  end
+
+  // ------
+  // Driver
+  // ------
+  // Slaves on same interconnect HierLevel
+  typedef acc_test::rand_c_slave #(
+    // Acc bus interface paramaters;
+    .DataWidth ( DataWidth  ),
+    .AddrWidth ( AddrWidth  ),
+    .IdWidth   ( ExtIdWidth ),
+    // Stimuli application and test time
+    .TA ( ApplTime ),
+    .TT ( TestTime )
+  ) rand_c_slave_t;
+
+  rand_c_slave_t rand_c_slave [NumRsp[HierLevel]];
+  for (genvar i=0; i<NumRsp[HierLevel]; i++) begin : gen_slv_driver
+    initial begin
+      rand_c_slave[i] = new (slave_dv[i]);
+      rand_c_slave[i].reset();
+      @(posedge rst_n);
+      rand_c_slave[i].run();
+    end
+  end
+
+  // Slaves on higher interconnect level.
+  typedef acc_test::rand_c_slave #(
+    // Acc bus interface paramaters;
+    .DataWidth ( DataWidth ),
+    .AddrWidth ( AddrWidth ),
+    .IdWidth   ( 1         ),
+    // Stimuli application and test time
+    .TA ( ApplTime ),
+    .TT ( TestTime )
+  ) rand_c_fwd_slave_t;
+
+
+  // Requests / responses originating from higher interconnect levels
+  // have already been sorted to the appropriate requester port.
+  rand_c_fwd_slave_t rand_c_fwd_slave[NumReq];
+  for (genvar i=0; i<NumReq; i++) begin : gen_c_slv_fwd_driver
+    initial begin
+      rand_c_fwd_slave[i] = new (slave_next_dv[i]);
+      rand_c_fwd_slave[i].reset();
+      @(posedge rst_n);
+      rand_c_fwd_slave[i].run();
+    end
+  end
+
+
+  typedef acc_test::rand_c_master #(
+    // Acc bus interface paramaters;
+    .DataWidth    ( DataWidth    ),
+    .AccAddrWidth ( AccAddrWidth ),
+    .AddrWidth    ( AddrWidth    ),
+    .IdWidth      ( 1            ),
+    .NumRsp       ( NumRsp       ),
+    .NumHier      ( NumHier      ),
+    .HierLevel    ( HierLevel    ),
+    // Stimuli application and test time
+    .TA ( ApplTime ),
+    .TT ( TestTime )
+  ) acc_rand_master_t;
+
+  acc_rand_master_t rand_c_master [NumReq];
+
+  for (genvar i = 0; i < NumReq; i++) begin : gen_c_master
+    initial begin
+      rand_c_master[i] = new (master_dv[i]);
+      rand_c_master[i].reset();
+      @(posedge rst_n);
+      rand_c_master[i].run(NrRandomTransactions);
+    end
+  end
+
+  // Compare reqs of different parameterizations
+  let mstslv_c_reqcompare(req_mst, req_slv) =
+    acc_test::compare_c_req#(
+      .mst_c_req_t ( tb_mst_c_req_t ),
+      .slv_c_req_t ( tb_slv_c_req_t )
+    )::do_compare(req_mst, req_slv);
+
+  // Compare rsps of different parameterizations
+  let mstslv_c_rspcompare(rsp_mst, rsp_slv) =
+    acc_test::compare_c_rsp#(
+      .mst_c_rsp_t ( tb_mst_c_rsp_t ),
+      .slv_c_rsp_t ( tb_slv_c_rsp_t )
+    )::do_compare(rsp_mst, rsp_slv);
+
+  // ----------
+  // Scoreboard
+  // ----------
+  // For each master check that each request sent has been received by
+  // the correct slave.
+  // For each slave, check that each response sent has been received by
+  // the correct master.
+  // Stop when all responses have been received.
+  //
+  // TODO: Add possibility for no-response requests.
+  //       For check if interconnect is correct, this is fine.
+
+  // Request Path
+  // ------------
+  initial begin
+    automatic int nr_requests = 0;
+    @(posedge rst_n);
+    for (int kk=0; kk<NumReq; kk++) begin // masters k
+      automatic int k=kk;
+      fork
+        // Check requests to same-level slaves
+        for (int ii=0; ii<NumRsp[HierLevel]; ii++) begin // slaves i
+          fork
+            automatic int i=ii;
+            forever begin : check_req_path
+              automatic tb_mst_c_req_t req_mst;
+              automatic tb_slv_c_req_t req_slv;
+              automatic tb_slv_c_req_t req_slv_all[NumReq];
+              // Master k has sent request to slave i.
+              // Check that slave i has received.
+              acc_c_slv_monitor[i].req_mbx[k<<1].get(req_slv);
+              acc_c_mst_monitor[k].req_mbx[i].get(req_mst);
+              assert(mstslv_c_reqcompare(req_mst, req_slv)) else
+                $error("Request Mismatch: C master %0d to C slave %0d", k, i);
+              // check that request was intended for slave i
+              assert(req_mst.addr[AccAddrWidth-1:0] == i) else
+                $error("Request Routing Error: C Master %0d", k);
+              nr_requests++;
+            end // -- forever
+          join_none
+        end // -- for (int i=0; i<NumRsp[HierLevel]; i++)
+
+        // Check forwarded requests
+        fork
+          forever begin : check_req_path
+            automatic tb_mst_c_req_t req_mst;
+            automatic tb_mst_c_req_t req_slv_fwd;
+            // Master k has sent interconnect forward port k
+            // Check that slave k has received.
+            acc_c_fwd_slv_monitor[k].req_mbx[0].get(req_slv_fwd);
+            acc_c_mst_monitor[k].req_mbx_fwd.get(req_mst);
+            assert(req_mst.do_compare(req_slv_fwd)) else
+              $error("Forwarded Request Mismatch: C Master %0d", k);
+            nr_requests++;
+          end // -- forever
+        join_none
+      join_none
+    end
+  end
+
+  // For each response received by a master, check that request has been issued.
+  initial begin
+    automatic int unsigned nr_responses = 0;
+    @(posedge rst_n);
+    for (int jj=0; jj<NumReq; jj++) begin
+      fork
+        automatic int j=jj;
+        forever begin
+          automatic tb_mst_c_rsp_t rsp_mst;
+          automatic tb_mst_c_rsp_t rsp_slv_fwd;
+          automatic bit rsp_sender_found = 0;
+          acc_c_mst_monitor[j].rsp_mbx.get(rsp_mst);
+          nr_responses++;
+          // Check this interconnect level
+          for (int l=0; l<NumRsp[HierLevel]; l++) begin
+            //$display("Slave monitor %0x, rsp_mbx[%0x], mbox!=0: ",l, j<<1, acc_c_slv_monitor[l].rsp_mbx[j<<1].num() != 0);
+            if (acc_c_slv_monitor[l].rsp_mbx[j<<1].num() != 0) begin
+              automatic tb_slv_c_rsp_t rsp_slv;
+              acc_c_slv_monitor[l].rsp_mbx[j<<1].peek(rsp_slv);
+              if (mstslv_c_rspcompare(rsp_mst, rsp_slv)) begin
+                acc_c_slv_monitor[l].rsp_mbx[j<<1].get(rsp_slv);
+                rsp_sender_found |= 1;
+                break;
+              end
+            end
+          end
+          // Check upper interconnect level (can only have originated
+          // from corresponding forward connection)
+          if (acc_c_fwd_slv_monitor[j].rsp_mbx[0].num() !=0 ) begin
+            acc_c_fwd_slv_monitor[j].rsp_mbx[0].peek(rsp_slv_fwd);
+            if (rsp_mst.do_compare(rsp_slv_fwd)) begin
+              acc_c_fwd_slv_monitor[j].rsp_mbx[0].get(rsp_slv_fwd);
+              rsp_sender_found |= 1;
+            end
+          end
+
+          assert(rsp_sender_found) else
+            $error("Master %0d: Received response but no Sender found", j);
+          if (nr_responses == NumReq * NrRandomTransactions) $finish;
+        end
+      join_none
+    end
+  end
+
+  final begin
+    for (int i=0; i<NumReq; i++) begin
+      assert(acc_c_mst_monitor[i].rsp_mbx.num() == 0);
+      assert(acc_c_mst_monitor[i].req_mbx_fwd.num() ==0);
+      assert(acc_c_fwd_slv_monitor[i].req_mbx[0].num()==0);
+      assert(acc_c_fwd_slv_monitor[i].rsp_mbx[0].num()==0);
+      for (int j=0; j<NumRsp[HierLevel]; j++) begin
+        assert(acc_c_mst_monitor[i].req_mbx[j].num() == 0);
+        assert(acc_c_slv_monitor[j].req_mbx[i].num() == 0);
+        assert(acc_c_slv_monitor[j].rsp_mbx[i].num() == 0);
+      end
+    end
+    $display("Checked for non-empty mailboxes.");
+  end
+
+  acc_interconnect_intf #(
+    .DataWidth     ( DataWidth         ),
+    .HierAddrWidth ( HierAddrWidth     ),
+    .AccAddrWidth  ( AccAddrWidth      ),
+    .HierLevel     ( HierLevel         ),
+    .NumReq        ( NumReq            ),
+    .NumRsp        ( NumRsp[HierLevel] ),
+    .RegisterReq   ( RegisterReq       ),
+    .RegisterRsp   ( RegisterRsp       )
+  ) dut (
+    .clk_i          ( clk        ),
+    .rst_ni         ( rst_n      ),
+    .acc_c_mst_next ( slave_next ),
+    .acc_c_mst      ( slave      ),
+    .acc_c_slv      ( master     )
+  );
+
+endmodule

--- a/test/acc_interconnect_tb.sv
+++ b/test/acc_interconnect_tb.sv
@@ -15,6 +15,8 @@ module acc_interconnect_tb  #(
   parameter int NumRsp[NumHier] = '{3,5,9},
   parameter int HierLevel       = 1, // 0, .., NumHier-1
   parameter int DataWidth       = 32,
+  parameter bit DualWriteback       = 0,
+  parameter bit TernaryOps          = 0,
   parameter bit RegisterReq     = 1,
   parameter bit RegisterRsp     = 1,
   // TB params
@@ -26,25 +28,20 @@ module acc_interconnect_tb  #(
   localparam int unsigned AccAddrWidth  = cf_math_pkg::idx_width(MaxNumRsp);
   localparam int unsigned HierAddrWidth = cf_math_pkg::idx_width(NumHier);
   localparam int unsigned AddrWidth     = AccAddrWidth + HierAddrWidth;
+  localparam int unsigned NumRs         = TernaryOps ? 3 : 2;
+  localparam int unsigned NumWb         = DualWriteback ? 2 : 1;
 
 
   typedef acc_test::c_req_t #(
     .AddrWidth ( AddrWidth ),
-    .DataWidth ( DataWidth )
-  ) tb_mst_c_req_t;
+    .DataWidth ( DataWidth ),
+    .NumRs     ( NumRs     )
+  ) tb_c_req_t;
 
   typedef acc_test::c_rsp_t #(
-    .DataWidth ( DataWidth )
-  ) tb_mst_c_rsp_t;
-
-  typedef acc_test::c_req_t #(
-    .AddrWidth ( AddrWidth ),
-    .DataWidth ( DataWidth )
-  ) tb_slv_c_req_t;
-
-  typedef acc_test::c_rsp_t #(
-    .DataWidth ( DataWidth )
-  ) tb_slv_c_rsp_t;
+    .DataWidth ( DataWidth ),
+    .NumWb     ( NumWb     )
+  ) tb_c_rsp_t;
 
   // Timing params
   localparam time ClkPeriod = 10ns;
@@ -54,37 +51,49 @@ module acc_interconnect_tb  #(
   logic clk, rst_n;
 
   ACC_C_BUS #(
-    .AddrWidth ( AddrWidth ),
-    .DataWidth ( DataWidth )
+    .AddrWidth     ( AddrWidth     ),
+    .DataWidth     ( DataWidth     ),
+    .DualWriteback ( DualWriteback ),
+    .TernaryOps    ( TernaryOps    )
   ) master[NumReq] ();
 
   ACC_C_BUS_DV #(
-    .AddrWidth ( AddrWidth ),
-    .DataWidth ( DataWidth )
+    .AddrWidth     ( AddrWidth     ),
+    .DataWidth     ( DataWidth     ),
+    .DualWriteback ( DualWriteback ),
+    .TernaryOps    ( TernaryOps    )
   ) master_dv[NumReq] (
     clk
   );
 
   ACC_C_BUS #(
-    .AddrWidth ( AddrWidth ),
-    .DataWidth ( DataWidth )
+    .AddrWidth     ( AddrWidth     ),
+    .DataWidth     ( DataWidth     ),
+    .DualWriteback ( DualWriteback ),
+    .TernaryOps    ( TernaryOps    )
   ) slave_next[NumReq] ();
 
   ACC_C_BUS_DV #(
-    .AddrWidth ( AddrWidth ),
-    .DataWidth ( DataWidth )
+    .AddrWidth     ( AddrWidth     ),
+    .DataWidth     ( DataWidth     ),
+    .DualWriteback ( DualWriteback ),
+    .TernaryOps    ( TernaryOps    )
   ) slave_next_dv[NumReq] (
     clk
   );
 
   ACC_C_BUS #(
-    .AddrWidth ( AddrWidth  ),
-    .DataWidth ( DataWidth  )
+    .AddrWidth     ( AddrWidth     ),
+    .DataWidth     ( DataWidth     ),
+    .DualWriteback ( DualWriteback ),
+    .TernaryOps    ( TernaryOps    )
   ) slave[NumRsp[HierLevel]] ();
 
   ACC_C_BUS_DV #(
-    .AddrWidth ( AddrWidth  ),
-    .DataWidth ( DataWidth  )
+    .AddrWidth     ( AddrWidth     ),
+    .DataWidth     ( DataWidth     ),
+    .DualWriteback ( DualWriteback ),
+    .TernaryOps    ( TernaryOps    )
   ) slave_dv[NumRsp[HierLevel]](
     clk
   );
@@ -121,20 +130,24 @@ module acc_interconnect_tb  #(
   // Monitor
   // -------
   typedef acc_test::acc_c_slv_monitor #(
-    .DataWidth ( DataWidth ),
-    .AddrWidth ( AddrWidth ),
-    .NumReq    ( NumReq    ),
-    .TA        ( ApplTime  ),
-    .TT        ( TestTime  )
+    .DataWidth     ( DataWidth     ),
+    .AddrWidth     ( AddrWidth     ),
+    .NumReq        ( NumReq        ),
+    .DualWriteback ( DualWriteback ),
+    .TernaryOps    ( TernaryOps    ),
+    .TA            ( ApplTime      ),
+    .TT            ( TestTime      )
   ) acc_c_slv_monitor_t;
 
   typedef acc_test::acc_c_mst_monitor #(
-    .DataWidth    ( DataWidth    ),
-    .AddrWidth    ( AddrWidth    ),
-    .AccAddrWidth ( AccAddrWidth ),
-    .HierLevel    ( HierLevel    ),
-    .TA           ( ApplTime     ),
-    .TT           ( TestTime     )
+    .DataWidth     ( DataWidth     ),
+    .AddrWidth     ( AddrWidth     ),
+    .AccAddrWidth  ( AccAddrWidth  ),
+    .HierLevel     ( HierLevel     ),
+    .DualWriteback ( DualWriteback ),
+    .TernaryOps    ( TernaryOps    ),
+    .TA            ( ApplTime      ),
+    .TT            ( TestTime      )
   ) acc_c_mst_monitor_t;
 
   acc_c_mst_monitor_t acc_c_mst_monitor[NumReq];
@@ -168,11 +181,13 @@ module acc_interconnect_tb  #(
   // Driver
   // ------
   typedef acc_test::rand_c_slave #(
-    .DataWidth ( DataWidth ),
-    .AddrWidth ( AddrWidth ),
-    .NumReq    ( NumReq    ),
-    .TA        ( ApplTime  ),
-    .TT        ( TestTime  )
+    .DataWidth     ( DataWidth     ),
+    .AddrWidth     ( AddrWidth     ),
+    .NumReq        ( NumReq        ),
+    .DualWriteback ( DualWriteback ),
+    .TernaryOps    ( TernaryOps    ),
+    .TA            ( ApplTime      ),
+    .TT            ( TestTime      )
   ) rand_c_slave_t;
 
   // Slaves connected to this interconnect level
@@ -198,14 +213,16 @@ module acc_interconnect_tb  #(
   end
 
   typedef acc_test::rand_c_master #(
-    .DataWidth    ( DataWidth    ),
-    .AccAddrWidth ( AccAddrWidth ),
-    .AddrWidth    ( AddrWidth    ),
-    .NumRsp       ( NumRsp       ),
-    .NumHier      ( NumHier      ),
-    .HierLevel    ( HierLevel    ),
-    .TA           ( ApplTime     ),
-    .TT           ( TestTime     )
+    .DataWidth     ( DataWidth     ),
+    .AccAddrWidth  ( AccAddrWidth  ),
+    .AddrWidth     ( AddrWidth     ),
+    .NumRsp        ( NumRsp        ),
+    .NumHier       ( NumHier       ),
+    .HierLevel     ( HierLevel     ),
+    .DualWriteback ( DualWriteback ),
+    .TernaryOps    ( TernaryOps    ),
+    .TA            ( ApplTime      ),
+    .TT            ( TestTime      )
   ) rand_c_master_t;
 
   rand_c_master_t rand_c_master[NumReq];
@@ -240,9 +257,9 @@ module acc_interconnect_tb  #(
           fork
             automatic int i = ii;
             forever begin : check_req_path
-              automatic tb_mst_c_req_t req_mst;
-              automatic tb_slv_c_req_t req_slv;
-              automatic tb_slv_c_req_t req_slv_all[NumReq];
+              automatic tb_c_req_t req_mst;
+              automatic tb_c_req_t req_slv;
+              automatic tb_c_req_t req_slv_all[NumReq];
               automatic int sender_id = -1;
               acc_c_slv_monitor[i].req_mbx_cnt.get_direct(req_slv, k);
               for (int l = 0; l < NumReq; l++) begin
@@ -267,8 +284,8 @@ module acc_interconnect_tb  #(
         // Check forwarded requests
         fork
           forever begin : check_req_path
-            automatic tb_mst_c_req_t req_mst;
-            automatic tb_mst_c_req_t req_slv_fwd;
+            automatic tb_c_req_t req_mst;
+            automatic tb_c_req_t req_slv_fwd;
             // Master k has sent interconnect forward port k
             // Check that slave k has received.
             acc_c_fwd_slv_monitor[k].req_mbx_cnt.get_direct(req_slv_fwd, 0);
@@ -290,15 +307,15 @@ module acc_interconnect_tb  #(
       fork
         automatic int j = jj;
         forever begin
-          automatic tb_mst_c_rsp_t rsp_mst;
-          automatic tb_mst_c_rsp_t rsp_slv_fwd;
+          automatic tb_c_rsp_t rsp_mst;
+          automatic tb_c_rsp_t rsp_slv_fwd;
           automatic bit rsp_sender_found = 0;
           acc_c_mst_monitor[j].rsp_mbx.get(rsp_mst);
           nr_responses++;
           // Check this interconnect level
           for (int l = 0; l < NumRsp[HierLevel]; l++) begin
             if (acc_c_slv_monitor[l].rsp_mbx_cnt.num(rsp_mst.hart_id) != 0) begin
-              automatic tb_slv_c_rsp_t rsp_slv;
+              automatic tb_c_rsp_t rsp_slv;
               acc_c_slv_monitor[l].rsp_mbx_cnt.peek(rsp_slv, rsp_mst.hart_id);
               if (rsp_mst.do_compare(rsp_slv)) begin
                 acc_c_slv_monitor[l].rsp_mbx_cnt.get(rsp_slv, rsp_mst.hart_id);
@@ -341,14 +358,16 @@ module acc_interconnect_tb  #(
   end
 
   acc_interconnect_intf #(
-    .DataWidth     ( DataWidth         ),
-    .HierAddrWidth ( HierAddrWidth     ),
-    .AccAddrWidth  ( AccAddrWidth      ),
-    .HierLevel     ( HierLevel         ),
-    .NumReq        ( NumReq            ),
-    .NumRsp        ( NumRsp[HierLevel] ),
-    .RegisterReq   ( RegisterReq       ),
-    .RegisterRsp   ( RegisterRsp       )
+    .DataWidth       ( DataWidth         ),
+    .HierAddrWidth   ( HierAddrWidth     ),
+    .AccAddrWidth    ( AccAddrWidth      ),
+    .HierLevel       ( HierLevel         ),
+    .NumReq          ( NumReq            ),
+    .NumRsp          ( NumRsp[HierLevel] ),
+      .DualWriteback ( DualWriteback     ),
+      .TernaryOps    ( TernaryOps        ),
+    .RegisterReq     ( RegisterReq       ),
+    .RegisterRsp     ( RegisterRsp       )
   ) dut (
     .clk_i          ( clk        ),
     .rst_ni         ( rst_n      ),

--- a/util/compile.sh
+++ b/util/compile.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2020 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
+# Andreas Kurth  <akurth@iis.ee.ethz.ch>
+
+set -e
+
+[ ! -z "$VSIM" ] || VSIM=vsim
+
+bender script vsim -t test \
+    --vlog-arg="-svinputport=compat" \
+    --vlog-arg="-override_timescale 1ns/1ps" \
+    --vlog-arg="-suppress 2583" \
+    --vlog-arg="+cover=sbecft" \
+    > compile.tcl
+echo 'return 0' >> compile.tcl
+$VSIM -c -do 'exit -code [source compile.tcl]'

--- a/util/run_vsim.sh
+++ b/util/run_vsim.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2020 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
+# Andreas Kurth  <akurth@iis.ee.ethz.ch>
+
+set -e
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+[ ! -z "$VSIM" ] || VSIM=vsim
+
+call_vsim() {
+    echo "log -r /*; run -all" | $VSIM -c -coverage -voptargs='+acc +cover=sbecft' "$@" | tee vsim.log 2>&1
+    grep "Errors: 0," vsim.log
+}
+
+call_vsim acc_adapter_tb
+call_vsim acc_interconnect_tb


### PR DESCRIPTION
* Accelerator Interconnect module (src/acc_interconnect.sv)
    Implements one hierarchy level of the the accelerator interconnect

* Accelerator Adapter module (src/acc_adapter.sv)
    Adapter between acc-agnostic offloading X-interface and accelerator
    C-interface

* Accelerator Predecoder module (src/acc_predecoder.sv)
    Per-extension instruction metadata predecoder

* Accelerator X/C/(PRD) interface definitions (src/acc_intf.sv)

* X/C- Interface / struct assignment and typedef macros (src/acc_interface/assign/typedef.sh)

Signed-off-by: ganoam <gnoam@live.com>