### PR TITLE
Add definitive encoding for c-/xmem_req_type signal

### DIFF
--- a/doc/c-interface.md
+++ b/doc/c-interface.md
@@ -99,7 +99,7 @@ The request channel signals from the accelerator units to the accelerator adapte
 | `q_laddr`            | `logic [DataWidth-1:0]`            | Accelerator > Adapter | Target logical memory address                             |
 | `q_wdata`            | `logic [DataWidth-1:0]`            | Accelerator > Adapter | Memory write data.                                        |
 | `q_width`            | `logic [2:0]`                      | Accelerator > Adapter | Memory access width (byte, half-word, word, [...])        |
-| `q_req_type`         | `logic [1:0]`                      | Accelerator > Adapter | Request type (X/W/R)                                      |
+| `q_req_type`         | `mem_req_type_e`                   | Accelerator > Adapter | Request type (R/W/X)                                      |
 | `q_mode`             | `logic`                            | Accelerator > Adapter | Memory access mode (standard / probe)                     |
 | `q_spec`             | `logic`                            | Accelerator > Adapter | Speculative memory operation (no trap upon access faults) |
 | `q_endoftransaction` | `logic`                            | Accelerator > Adapter | Indicates the end of a memory operation sequence          |

--- a/doc/x-interface.md
+++ b/doc/x-interface.md
@@ -103,7 +103,7 @@ The request channel signals from the adapter to the offloading core are:
 | `q_laddr`            | `logic [DataWidth-1:0]` | Adapter > Core | Target logical memory address                             |
 | `q_wdata`            | `logic [DataWidth-1:0]` | Adapter > Core | Memory write data                                         |
 | `q_width`            | `logic [1:0]`           | Adapter > Core | Memory access width (byte, half-word, word, [...])        |
-| `q_req_type`         | `logic [1:0]`           | Adapter > Core | Request type (X/W/R)                                      |
+| `q_req_type`         | `mem_req_type_e`        | Adapter > Core | Request type (R/W/X)                                      |
 | `q_mode`             | `logic`                 | Adapter > Core | Memory access mode (standard / probe)                     |
 | `q_spec`             | `logic`                 | Adapter > Core | Speculative memory operation (no trap upon access faults) |
 | `q_endoftransaction` | `logic`                 | Adapter > Core | Indicates the end of a memory operation sequence          |

--- a/include/acc_interface/typedef.svh
+++ b/include/acc_interface/typedef.svh
@@ -55,17 +55,17 @@
 // ACC_CMEM Typedefs //
 ///////////////////////
 
-`define ACC_CMEM_TYPEDEF_REQ_CHAN_T(__req_chan_t, __addr_t, __data_t) \
-  typedef struct packed {                                             \
-    __data_t    laddr;                                                \
-    __data_t    wdata;                                                \
-    logic [2:0] width;                                                \
-    logic [1:0] req_type;                                             \
-    logic       mode;                                                 \
-    logic       spec;                                                 \
-    logic       endoftransaction;                                     \
-    __data_t    hart_id;                                              \
-    __addr_t    addr;                                                 \
+`define ACC_CMEM_TYPEDEF_REQ_CHAN_T(__req_chan_t, __addr_t, __data_t, __mem_req_type_e) \
+  typedef struct packed {                                                               \
+    __data_t         laddr;                                                             \
+    __data_t         wdata;                                                             \
+    logic [2:0]      width;                                                             \
+    __mem_req_type_e req_type;                                                          \
+    logic            mode;                                                              \
+    logic            spec;                                                              \
+    logic            endoftransaction;                                                  \
+    __data_t         hart_id;                                                           \
+    __addr_t         addr;                                                              \
   } __req_chan_t;
 
 `define ACC_CMEM_TYPEDEF_REQ_T(__req_t, __req_chan_t) \
@@ -91,10 +91,10 @@
     logic        q_ready;                             \
   } __rsp_t;
 
-`define ACC_CMEM_TYPEDEF_ALL(__name, __addr_t, __data_t)                \
-  `ACC_CMEM_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t, __addr_t, __data_t) \
-  `ACC_CMEM_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __addr_t, __data_t) \
-  `ACC_CMEM_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t )         \
+`define ACC_CMEM_TYPEDEF_ALL(__name, __addr_t, __data_t, __mem_req_type_e)                \
+  `ACC_CMEM_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t, __addr_t, __data_t, __mem_req_type_e) \
+  `ACC_CMEM_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __addr_t, __data_t)                   \
+  `ACC_CMEM_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t )                           \
   `ACC_CMEM_TYPEDEF_RSP_T(__name``_rsp_t,  __name``_rsp_chan_t )
 
 ////////////////////
@@ -152,15 +152,15 @@
 // ACC_XMEM Typedefs //
 ///////////////////////
 
-`define ACC_XMEM_TYPEDEF_REQ_CHAN_T(__req_chan_t,  __data_t) \
-  typedef struct packed {                                    \
-    __data_t    laddr;                                       \
-    __data_t    wdata;                                       \
-    logic [2:0] width;                                       \
-    logic [1:0] req_type;                                    \
-    logic       mode;                                        \
-    logic       spec;                                        \
-    logic       endoftransaction;                            \
+`define ACC_XMEM_TYPEDEF_REQ_CHAN_T(__req_chan_t,  __data_t, __mem_req_type_e) \
+  typedef struct packed {                                                      \
+    __data_t         laddr;                                                    \
+    __data_t         wdata;                                                    \
+    logic [2:0]      width;                                                    \
+    __mem_req_type_e req_type;                                                 \
+    logic            mode;                                                     \
+    logic            spec;                                                     \
+    logic            endoftransaction;                                         \
   } __req_chan_t;
 
 `define ACC_XMEM_TYPEDEF_REQ_T(__req_t, __req_chan_t) \
@@ -184,8 +184,8 @@
     logic        q_ready;                             \
   } __rsp_t;
 
-`define ACC_XMEM_TYPEDEF_ALL(__name,  __data_t)                \
-  `ACC_XMEM_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t,  __data_t) \
-  `ACC_XMEM_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __data_t)           \
-  `ACC_XMEM_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t)          \
+`define ACC_XMEM_TYPEDEF_ALL(__name,  __data_t, __mem_req_type_e)                \
+  `ACC_XMEM_TYPEDEF_REQ_CHAN_T(__name``_req_chan_t,  __data_t, __mem_req_type_e) \
+  `ACC_XMEM_TYPEDEF_RSP_CHAN_T(__name``_rsp_chan_t, __data_t)                    \
+  `ACC_XMEM_TYPEDEF_REQ_T(__name``_req_t, __name``_req_chan_t)                   \
   `ACC_XMEM_TYPEDEF_RSP_T(__name``_rsp_t,  __name``_rsp_chan_t)

--- a/src/acc_pkg.sv
+++ b/src/acc_pkg.sv
@@ -90,11 +90,17 @@ package acc_pkg;
   typedef logic [AddrWidth-1:0] addr_t;
   typedef logic [         31:0] data_t;
 
+  typedef enum logic [1:0] {
+  READ     = 2'b00,
+  WRITE    = 2'b01,
+  EXECUTE  = 2'b10
+  } mem_req_type_e;
+
   // Interface Typedefs
   `ACC_C_TYPEDEF_ALL(acc_c, addr_t, data_t, NumRs, NumWb)
   `ACC_X_TYPEDEF_ALL(acc_x, data_t, NumRs, NumWb)
-  `ACC_CMEM_TYPEDEF_ALL(acc_cmem, addr_t, data_t)
-  `ACC_XMEM_TYPEDEF_ALL(acc_xmem, data_t)
+  `ACC_CMEM_TYPEDEF_ALL(acc_cmem, addr_t, data_t, mem_req_type_e)
+  `ACC_XMEM_TYPEDEF_ALL(acc_xmem, data_t, mem_req_type_e)
 
   // Predecoder response type
   typedef struct packed {


### PR DESCRIPTION
I issue this PR as agreed in the bi-weekly cv-x-if meeting. See [Meeting Minutes from 31.05.2021](https://github.com/openhwgroup/core-v-docs/blob/master/cores/cv-x-if/meeting_minutes/May.31.2021.md).
This change adds a definitive encoding for the cmem_req_type and xmem_req_type signal, which is necessairy for the memory interface to be general and not core/accelerator specific.